### PR TITLE
Build for Node.js 4.x, make tests compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- "6.0.0"
-- "lts/*"
+- "4"
+- "node"
 sudo: false
 cache:
   directories:

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -2,7 +2,8 @@ const crypto = require('crypto');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
-const {Asset, AssetType} = ScratchStorage;
+const Asset = ScratchStorage.Asset;
+const AssetType = ScratchStorage.AssetType;
 
 /**
  *
@@ -39,7 +40,7 @@ const testAssets = [
     }
 ];
 
-let storage;
+var storage;
 test('constructor', t => {
     storage = new ScratchStorage();
     t.type(storage, ScratchStorage);
@@ -51,10 +52,10 @@ test('addWebSource', t => {
         storage.addWebSource(
             [AssetType.Project],
             asset => {
-                const [projectId, revision] = asset.assetId.split('.');
-                return revision ?
-                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/${revision}` :
-                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/`;
+                const idParts = asset.assetId.split('.');
+                return idParts[1] ?
+                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${idParts[0]}/get/${idParts[1]}` :
+                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${idParts[0]}/get/`;
             });
     });
     t.doesNotThrow(() => {
@@ -68,7 +69,7 @@ test('addWebSource', t => {
 
 test('load', t => {
     const promises = [];
-    for (let i = 0; i < testAssets.length; ++i) {
+    for (var i = 0; i < testAssets.length; ++i) {
         const assetInfo = testAssets[i];
 
         const promise = storage.load(assetInfo.type, assetInfo.id);

--- a/test/unit/load-default-assets.js
+++ b/test/unit/load-default-assets.js
@@ -2,12 +2,13 @@ const crypto = require('crypto');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
-const {Asset, AssetType} = ScratchStorage;
+const Asset = ScratchStorage.Asset;
+const AssetType = ScratchStorage.AssetType;
 
 const defaultAssetTypes = [AssetType.ImageBitmap, AssetType.ImageVector, AssetType.Sound];
 const defaultIds = {};
 
-let storage;
+var storage;
 test('constructor', t => {
     storage = new ScratchStorage();
     t.type(storage, ScratchStorage);
@@ -15,7 +16,7 @@ test('constructor', t => {
 });
 
 test('getDefaultAssetId', t => {
-    for (let i = 0; i < defaultAssetTypes.length; ++i) {
+    for (var i = 0; i < defaultAssetTypes.length; ++i) {
         const assetType = defaultAssetTypes[i];
         const id = storage.getDefaultAssetId(assetType);
         t.type(id, 'string');
@@ -26,7 +27,7 @@ test('getDefaultAssetId', t => {
 
 test('load', t => {
     const promises = [];
-    for (let i = 0; i < defaultAssetTypes.length; ++i) {
+    for (var i = 0; i < defaultAssetTypes.length; ++i) {
         const assetType = defaultAssetTypes[i];
         const id = defaultIds[assetType.name];
 


### PR DESCRIPTION
### Proposed Changes

Tell Travis CI to build for Node.js 4.x in addition to the latest stable version. The tests were using language features not available in 4.x, so they have been adjusted.

### Reason for Changes

This makes `scratch-storage` more consistent with other Scratch 3.0 repositories, all of which currently build for Node.js 4.x as part of their CI setup.
