### PR TITLE
Offer unpacked code from package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "4"
+- "6"
 - "node"
 sudo: false
 cache:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "^3.14.1",
     "eslint-config-scratch": "^3.1.0",
     "eslint-plugin-react": "^6.9.0",
+    "jsdom": "^9.12.0",
     "json": "^9.0.4",
     "tap": "^8.0.1",
     "travis-after-all": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/LLK/scratch-storage.git"
   },
-  "main": "./dist/node/scratch-storage.js",
+  "main": "./src/index.js",
   "scripts": {
     "build": "./node_modules/.bin/webpack --progress --colors --bail",
     "coverage": "./node_modules/.bin/tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",
@@ -21,24 +21,23 @@
     "version": "./node_modules/.bin/json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
     "watch": "./node_modules/.bin/webpack --progress --colors --watch"
   },
+  "dependencies": {
+    "binary-loader": "0.0.1",
+    "got": "5.7.1",
+    "localforage": "1.5.0",
+    "text-encoding": "0.6.4"
+  },
   "devDependencies": {
     "babel-core": "6.22.1",
     "babel-eslint": "7.1.1",
     "babel-loader": "6.2.10",
     "babel-polyfill": "6.22.0",
     "babel-preset-es2015": "6.22.0",
-    "binary-loader": "0.0.1",
-    "debug": "2.6.0",
-    "eslint": "3.14.1",
-    "eslint-config-scratch": "3.1.0",
-    "eslint-plugin-react": "6.9.0",
-    "file-loader": "0.9.0",
-    "got": "5.7.1",
+    "eslint": "^3.14.1",
+    "eslint-config-scratch": "^3.1.0",
+    "eslint-plugin-react": "^6.9.0",
     "json": "^9.0.4",
-    "json-loader": "0.5.4",
-    "localforage": "1.5.0",
-    "tap": "8.0.1",
-    "text-encoding": "0.6.4",
+    "tap": "^8.0.1",
     "travis-after-all": "^1.4.4",
     "webpack": "2.2.1"
   }

--- a/test/fixtures/jsdomTest.js
+++ b/test/fixtures/jsdomTest.js
@@ -1,0 +1,41 @@
+const jsdom = require('jsdom');
+const test = require('tap').test;
+
+const virtualConsole = jsdom.createVirtualConsole();
+virtualConsole.on('jsdomError', error => {
+    throw error;
+});
+
+/**
+ * Run `tests` in a jsdom environment built with the provided options.
+ * Note that any "done" callback in your options will be replaced by a call to `tests`.
+ * @param {function} tests - the tests to run in the jsdom environment. This will be called with one "window" argument.
+ * @param {object} options - the jsdom options; see `jsdom.env` documentation.
+ * @example
+ *   jsdomTest(
+ *     (window) => {
+ *       test('test1', t => { window.foo.doStuff(); t.end(); });
+ *       test('test2', t => { window.foo.doOther(); t.end(); });
+ *     },
+ *     '<html><body>Web page for tests</body></html>',
+ *     [require.resolve('path/to/script/under/test')]
+ *   );
+ */
+const jsdomTest = function (tests, ...options) {
+    test('jsdomTest', () => new Promise((resolve, reject) => {
+        // The 0 is here to suppress "optimization" in jsdom's getConfigFromArguments.
+        // It can be anything that isn't a string, function, or object.
+        options.unshift(0, {virtualConsole});
+        options.push((err, window) => {
+            if (err) {
+                reject(err);
+            } else {
+                tests(window);
+                resolve();
+            }
+        });
+        jsdom.env.apply(null, options);
+    }));
+};
+
+module.exports = jsdomTest;

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -1,94 +1,108 @@
 const crypto = require('crypto');
 const test = require('tap').test;
 
-const ScratchStorage = require('../../dist/node/scratch-storage');
-const {Asset, AssetType} = ScratchStorage;
+const jsdomTest = require('../fixtures/jsdomTest');
 
 /**
- *
- * @type {AssetTestInfo[]}
- * @typedef {object} AssetTestInfo
- * @property {AssetType} type - The type of the asset.
- * @property {string} id - The asset's unique ID.
+ * These tests will run inside the jsdom "window" after loading the script under test.
+ * @param {object} window - the jsdom window.
  */
-const testAssets = [
-    {
-        type: AssetType.Project,
-        id: '117504922',
-        md5: null // don't check MD5 for project without revision ID
-    },
-    {
-        type: AssetType.Project,
-        id: '117504922.d6ae1ffb76f2bc83421cd3f40fc4fd57',
-        md5: '1225460702e149727de28bff4cfd9e23'
-    },
-    {
-        type: AssetType.ImageVector,
-        id: 'f88bf1935daea28f8ca098462a31dbb0', // cat1-a
-        md5: 'f88bf1935daea28f8ca098462a31dbb0'
-    },
-    {
-        type: AssetType.ImageBitmap,
-        id: '7e24c99c1b853e52f8e7f9004416fa34', // squirrel
-        md5: '7e24c99c1b853e52f8e7f9004416fa34'
-    },
-    {
-        type: AssetType.Sound,
-        id: '83c36d806dc92327b9e7049a565c6bff', // meow
-        md5: '83c36d806dc92327b9e7049a565c6bff' // wat
-    }
-];
+const hostedTests = function (window) {
+    const ScratchStorage = window.Scratch.Storage;
+    const {Asset, AssetType} = ScratchStorage;
 
-let storage;
-test('constructor', t => {
-    storage = new ScratchStorage();
-    t.type(storage, ScratchStorage);
-    t.end();
-});
+    /**
+     *
+     * @type {AssetTestInfo[]}
+     * @typedef {object} AssetTestInfo
+     * @property {AssetType} type - The type of the asset.
+     * @property {string} id - The asset's unique ID.
+     */
+    const testAssets = [
+        {
+            type: AssetType.Project,
+            id: '117504922',
+            md5: null // don't check MD5 for project without revision ID
+        },
+        {
+            type: AssetType.Project,
+            id: '117504922.d6ae1ffb76f2bc83421cd3f40fc4fd57',
+            md5: '1225460702e149727de28bff4cfd9e23'
+        },
+        {
+            type: AssetType.ImageVector,
+            id: 'f88bf1935daea28f8ca098462a31dbb0', // cat1-a
+            md5: 'f88bf1935daea28f8ca098462a31dbb0'
+        },
+        {
+            type: AssetType.ImageBitmap,
+            id: '7e24c99c1b853e52f8e7f9004416fa34', // squirrel
+            md5: '7e24c99c1b853e52f8e7f9004416fa34'
+        },
+        {
+            type: AssetType.Sound,
+            id: '83c36d806dc92327b9e7049a565c6bff', // meow
+            md5: '83c36d806dc92327b9e7049a565c6bff' // wat
+        }
+    ];
 
-test('addWebSource', t => {
-    t.doesNotThrow(() => {
-        storage.addWebSource(
-            [AssetType.Project],
-            asset => {
-                const [projectId, revision] = asset.assetId.split('.');
-                return revision ?
-                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/${revision}` :
-                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/`;
-            });
+    let storage;
+    test('constructor', t => {
+        storage = new ScratchStorage();
+        t.type(storage, ScratchStorage);
+        t.end();
     });
-    t.doesNotThrow(() => {
-        storage.addWebSource(
-            [AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound],
-            asset => `https://cdn.assets.scratch.mit.edu/internalapi/asset/${asset.assetId}.${asset.assetType.runtimeFormat}/get/`
-        );
-    });
-    t.end();
-});
 
-test('load', t => {
-    const promises = [];
-    for (let i = 0; i < testAssets.length; ++i) {
-        const assetInfo = testAssets[i];
-
-        const promise = storage.load(assetInfo.type, assetInfo.id);
-        t.type(promise, 'Promise');
-
-        promises.push(promise);
-
-        promise.then(asset => {
-            t.type(asset, Asset);
-            t.strictEqual(asset.assetId, assetInfo.id);
-            t.strictEqual(asset.assetType, assetInfo.type);
-            t.ok(asset.data.length);
-
-            if (assetInfo.md5) {
-                const hash = crypto.createHash('md5');
-                hash.update(asset.data);
-                t.strictEqual(hash.digest('hex'), assetInfo.md5);
-            }
+    test('addWebSource', t => {
+        t.doesNotThrow(() => {
+            storage.addWebSource(
+                [AssetType.Project],
+                asset => {
+                    const [projectId, revision] = asset.assetId.split('.');
+                    return revision ?
+                        `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/${revision}` :
+                        `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/`;
+                });
         });
-    }
+        t.doesNotThrow(() => {
+            storage.addWebSource(
+                [AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound],
+                asset => `https://cdn.assets.scratch.mit.edu/internalapi/asset/${asset.assetId}.${asset.assetType.runtimeFormat}/get/`
+            );
+        });
+        t.end();
+    });
 
-    return Promise.all(promises);
-});
+    test('load', t => {
+        const promises = [];
+        for (let i = 0; i < testAssets.length; ++i) {
+            const assetInfo = testAssets[i];
+
+            const promise = storage.load(assetInfo.type, assetInfo.id);
+            t.type(promise, 'Promise');
+
+            promises.push(promise);
+
+            promise.then(asset => {
+                t.type(asset, Asset);
+                t.strictEqual(asset.assetId, assetInfo.id);
+                t.strictEqual(asset.assetType, assetInfo.type);
+                t.ok(asset.data.length);
+
+                if (assetInfo.md5) {
+                    const hash = crypto.createHash('md5');
+                    hash.update(asset.data);
+                    t.strictEqual(hash.digest('hex'), assetInfo.md5);
+                }
+            });
+        }
+
+        return Promise.all(promises);
+    });
+};
+
+jsdomTest(
+    hostedTests,
+    '<html><body></body></html>',
+    [require.resolve('../../dist/web/scratch-storage')]
+);

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -2,8 +2,7 @@ const crypto = require('crypto');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
-const Asset = ScratchStorage.Asset;
-const AssetType = ScratchStorage.AssetType;
+const {Asset, AssetType} = ScratchStorage;
 
 /**
  *
@@ -40,7 +39,7 @@ const testAssets = [
     }
 ];
 
-var storage;
+let storage;
 test('constructor', t => {
     storage = new ScratchStorage();
     t.type(storage, ScratchStorage);
@@ -52,10 +51,10 @@ test('addWebSource', t => {
         storage.addWebSource(
             [AssetType.Project],
             asset => {
-                const idParts = asset.assetId.split('.');
-                return idParts[1] ?
-                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${idParts[0]}/get/${idParts[1]}` :
-                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${idParts[0]}/get/`;
+                const [projectId, revision] = asset.assetId.split('.');
+                return revision ?
+                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/${revision}` :
+                    `https://cdn.projects.scratch.mit.edu/internalapi/project/${projectId}/get/`;
             });
     });
     t.doesNotThrow(() => {
@@ -69,7 +68,7 @@ test('addWebSource', t => {
 
 test('load', t => {
     const promises = [];
-    for (var i = 0; i < testAssets.length; ++i) {
+    for (let i = 0; i < testAssets.length; ++i) {
         const assetInfo = testAssets[i];
 
         const promise = storage.load(assetInfo.type, assetInfo.id);

--- a/test/unit/load-default-assets.js
+++ b/test/unit/load-default-assets.js
@@ -1,51 +1,65 @@
 const crypto = require('crypto');
 const test = require('tap').test;
 
-const ScratchStorage = require('../../dist/node/scratch-storage');
-const {Asset, AssetType} = ScratchStorage;
+const jsdomTest = require('../fixtures/jsdomTest');
 
-const defaultAssetTypes = [AssetType.ImageBitmap, AssetType.ImageVector, AssetType.Sound];
-const defaultIds = {};
+/**
+ * These tests will run inside the jsdom "window" after loading the script under test.
+ * @param {object} window - the jsdom window.
+ */
+const hostedTests = function (window) {
+    const ScratchStorage = window.Scratch.Storage;
+    const {Asset, AssetType} = ScratchStorage;
 
-let storage;
-test('constructor', t => {
-    storage = new ScratchStorage();
-    t.type(storage, ScratchStorage);
-    t.end();
-});
+    const defaultAssetTypes = [AssetType.ImageBitmap, AssetType.ImageVector, AssetType.Sound];
+    const defaultIds = {};
 
-test('getDefaultAssetId', t => {
-    for (let i = 0; i < defaultAssetTypes.length; ++i) {
-        const assetType = defaultAssetTypes[i];
-        const id = storage.getDefaultAssetId(assetType);
-        t.type(id, 'string');
-        defaultIds[assetType.name] = id;
-    }
-    t.end();
-});
+    let storage;
+    test('constructor', t => {
+        storage = new ScratchStorage();
+        t.type(storage, ScratchStorage);
+        t.end();
+    });
 
-test('load', t => {
-    const promises = [];
-    for (let i = 0; i < defaultAssetTypes.length; ++i) {
-        const assetType = defaultAssetTypes[i];
-        const id = defaultIds[assetType.name];
+    test('getDefaultAssetId', t => {
+        for (let i = 0; i < defaultAssetTypes.length; ++i) {
+            const assetType = defaultAssetTypes[i];
+            const id = storage.getDefaultAssetId(assetType);
+            t.type(id, 'string');
+            defaultIds[assetType.name] = id;
+        }
+        t.end();
+    });
 
-        const promise = storage.load(assetType, id);
-        t.type(promise, 'Promise');
+    test('load', t => {
+        const promises = [];
+        for (let i = 0; i < defaultAssetTypes.length; ++i) {
+            const assetType = defaultAssetTypes[i];
+            const id = defaultIds[assetType.name];
 
-        promises.push(promise);
+            const promise = storage.load(assetType, id);
+            t.type(promise, 'Promise');
 
-        promise.then(asset => {
-            t.type(asset, Asset);
-            t.strictEqual(asset.assetId, id);
-            t.strictEqual(asset.assetType, assetType);
-            t.ok(asset.data.length);
+            promises.push(promise);
 
-            const hash = crypto.createHash('md5');
-            hash.update(asset.data);
-            t.strictEqual(hash.digest('hex'), id);
-        });
-    }
+            promise.then(asset => {
+                t.type(asset, Asset);
+                t.strictEqual(asset.assetId, id);
+                t.strictEqual(asset.assetType, assetType);
+                t.ok(asset.data.length);
 
-    return Promise.all(promises);
-});
+                const hash = crypto.createHash('md5');
+                hash.update(asset.data);
+                t.strictEqual(hash.digest('hex'), id);
+            });
+        }
+
+        return Promise.all(promises);
+    });
+};
+
+jsdomTest(
+    hostedTests,
+    '<html><body></body></html>',
+    [require.resolve('../../dist/web/scratch-storage')]
+);

--- a/test/unit/load-default-assets.js
+++ b/test/unit/load-default-assets.js
@@ -2,13 +2,12 @@ const crypto = require('crypto');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
-const Asset = ScratchStorage.Asset;
-const AssetType = ScratchStorage.AssetType;
+const {Asset, AssetType} = ScratchStorage;
 
 const defaultAssetTypes = [AssetType.ImageBitmap, AssetType.ImageVector, AssetType.Sound];
 const defaultIds = {};
 
-var storage;
+let storage;
 test('constructor', t => {
     storage = new ScratchStorage();
     t.type(storage, ScratchStorage);
@@ -16,7 +15,7 @@ test('constructor', t => {
 });
 
 test('getDefaultAssetId', t => {
-    for (var i = 0; i < defaultAssetTypes.length; ++i) {
+    for (let i = 0; i < defaultAssetTypes.length; ++i) {
         const assetType = defaultAssetTypes[i];
         const id = storage.getDefaultAssetId(assetType);
         t.type(id, 'string');
@@ -27,7 +26,7 @@ test('getDefaultAssetId', t => {
 
 test('load', t => {
     const promises = [];
-    for (var i = 0; i < defaultAssetTypes.length; ++i) {
+    for (let i = 0; i < defaultAssetTypes.length; ++i) {
         const assetType = defaultAssetTypes[i];
         const id = defaultIds[assetType.name];
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,20 +1,25 @@
-const path = require('path');
 const webpack = require('webpack');
 
-const base = {
+module.exports = {
+    devtool: 'cheap-module-source-map',
+    entry: {
+        'scratch-storage': './src/index-web.js',
+        'scratch-storage.min': './src/index-web.js'
+    },
     module: {
         rules: [
             {
-                include: [
-                    path.resolve(__dirname, 'src')
-                ],
-                test: /\.js$/,
+                test: /[\\/]+scratch-[^\\/]+[\\/]+src[\\/]+.+\.js$/,
                 loader: 'babel-loader',
                 options: {
                     presets: ['es2015']
                 }
             }
         ]
+    },
+    output: {
+        path: __dirname,
+        filename: 'dist/web/[name].js'
     },
     plugins: [
         new webpack.optimize.UglifyJsPlugin({
@@ -24,32 +29,3 @@ const base = {
         })
     ]
 };
-
-module.exports = [
-    // Web-compatible
-    Object.assign({}, base, {
-        target: 'web',
-        entry: {
-            'scratch-storage': './src/index-web.js',
-            'scratch-storage.min': './src/index-web.js'
-        },
-        output: {
-            path: __dirname,
-            filename: 'dist/web/[name].js'
-        }
-    }),
-
-    // Node-compatible
-    Object.assign({}, base, {
-        target: 'node',
-        entry: {
-            'scratch-storage': './src/index.js'
-        },
-        output: {
-            library: 'ScratchStorage',
-            libraryTarget: 'commonjs2',
-            path: __dirname,
-            filename: 'dist/node/[name].js'
-        }
-    })
-];


### PR DESCRIPTION
### Proposed Changes

This change declares `./src/index.js` as the "main" script in `package.json`, and stops building `dist/node/*` with webpack. This change also restores the ES6 version of the test scripts, recently altered for Node.js 4.x compatibility.

### Reason for Changes

This sets us up to build `scratch-gui` in a single step, allowing webpack to better optimize our files and reducing the duplication of code within our output bundles.

### Test Coverage

Test coverage has not changed -- just the syntax of the test scripts.
