### PR TITLE
Standardize repository settings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 const base = {
+    devtool: 'cheap-module-source-map',
     module: {
         rules: [
             {


### PR DESCRIPTION
### Proposed Changes

This change ensures that the source map settings are similar to other Scratch 3.0 repositories. This was previously part of #6.
