### PR TITLE
Add `Asset` and `AssetType` to storage instance

### DIFF
--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -16,6 +16,40 @@ class ScratchStorage {
     }
 
     /**
+     * @return {Asset} - the `Asset` class constructor.
+     * @constructor
+     */
+    get Asset () {
+        return Asset;
+    }
+
+    /**
+     * @return {AssetType} - the list of supported asset types.
+     * @constructor
+     */
+    get AssetType () {
+        return AssetType;
+    }
+
+    /**
+     * @deprecated Please use the `Asset` member of a storage instance instead.
+     * @return {Asset} - the `Asset` class constructor.
+     * @constructor
+     */
+    static get Asset () {
+        return Asset;
+    }
+
+    /**
+     * @deprecated Please use the `AssetType` member of a storage instance instead.
+     * @return {AssetType} - the list of supported asset types.
+     * @constructor
+     */
+    static get AssetType () {
+        return AssetType;
+    }
+
+    /**
      * Register a web-based source for assets. Sources will be checked in order of registration.
      * @param {Array.<AssetType>} types - The types of asset provided by this source.
      * @param {UrlFunction} urlFunction - A function which computes a URL from an Asset.
@@ -96,10 +130,5 @@ class ScratchStorage {
         });
     }
 }
-
-Object.assign(ScratchStorage.prototype, {
-    Asset,
-    AssetType
-});
 
 module.exports = ScratchStorage;

--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -1,3 +1,5 @@
+const Asset = require('./Asset');
+const AssetType = require('./AssetType');
 const BuiltinHelper = require('./BuiltinHelper');
 const LocalHelper = require('./LocalHelper');
 const WebHelper = require('./WebHelper');
@@ -94,5 +96,10 @@ class ScratchStorage {
         });
     }
 }
+
+Object.assign(ScratchStorage.prototype, {
+    Asset,
+    AssetType
+});
 
 module.exports = ScratchStorage;

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,7 @@
-const Asset = require('./Asset');
-const AssetType = require('./AssetType');
 const ScratchStorage = require('./ScratchStorage');
 
 /**
  * Export for use with NPM & Node.js.
  * @type {ScratchStorage}
  */
-module.exports = Object.assign(ScratchStorage, {
-    /**
-     * Please use the `Asset` member of a storage instance instead.
-     * @deprecated
-     */
-    Asset: Asset,
-
-    /**
-     * Please use the `AssetType` member of a storage instance instead.
-     * @deprecated
-     */
-    AssetType: AssetType
-});
+module.exports = ScratchStorage;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,15 @@ const ScratchStorage = require('./ScratchStorage');
  * @type {ScratchStorage}
  */
 module.exports = Object.assign(ScratchStorage, {
+    /**
+     * Please use the `Asset` member of a storage instance instead.
+     * @deprecated
+     */
     Asset: Asset,
+
+    /**
+     * Please use the `AssetType` member of a storage instance instead.
+     * @deprecated
+     */
     AssetType: AssetType
 });

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -2,8 +2,13 @@ const crypto = require('crypto');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
-const Asset = ScratchStorage.Asset;
-const AssetType = ScratchStorage.AssetType;
+
+var storage;
+test('constructor', t => {
+    storage = new ScratchStorage();
+    t.type(storage, ScratchStorage);
+    t.end();
+});
 
 /**
  *
@@ -14,43 +19,36 @@ const AssetType = ScratchStorage.AssetType;
  */
 const testAssets = [
     {
-        type: AssetType.Project,
+        type: storage.AssetType.Project,
         id: '117504922',
         md5: null // don't check MD5 for project without revision ID
     },
     {
-        type: AssetType.Project,
+        type: storage.AssetType.Project,
         id: '117504922.d6ae1ffb76f2bc83421cd3f40fc4fd57',
         md5: '1225460702e149727de28bff4cfd9e23'
     },
     {
-        type: AssetType.ImageVector,
+        type: storage.AssetType.ImageVector,
         id: 'f88bf1935daea28f8ca098462a31dbb0', // cat1-a
         md5: 'f88bf1935daea28f8ca098462a31dbb0'
     },
     {
-        type: AssetType.ImageBitmap,
+        type: storage.AssetType.ImageBitmap,
         id: '7e24c99c1b853e52f8e7f9004416fa34', // squirrel
         md5: '7e24c99c1b853e52f8e7f9004416fa34'
     },
     {
-        type: AssetType.Sound,
+        type: storage.AssetType.Sound,
         id: '83c36d806dc92327b9e7049a565c6bff', // meow
         md5: '83c36d806dc92327b9e7049a565c6bff' // wat
     }
 ];
 
-var storage;
-test('constructor', t => {
-    storage = new ScratchStorage();
-    t.type(storage, ScratchStorage);
-    t.end();
-});
-
 test('addWebSource', t => {
     t.doesNotThrow(() => {
         storage.addWebSource(
-            [AssetType.Project],
+            [storage.AssetType.Project],
             asset => {
                 const idParts = asset.assetId.split('.');
                 return idParts[1] ?
@@ -60,7 +58,7 @@ test('addWebSource', t => {
     });
     t.doesNotThrow(() => {
         storage.addWebSource(
-            [AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound],
+            [storage.AssetType.ImageVector, storage.AssetType.ImageBitmap, storage.AssetType.Sound],
             asset => `https://cdn.assets.scratch.mit.edu/internalapi/asset/${asset.assetId}.${asset.assetType.runtimeFormat}/get/`
         );
     });
@@ -78,7 +76,7 @@ test('load', t => {
         promises.push(promise);
 
         promise.then(asset => {
-            t.type(asset, Asset);
+            t.type(asset, storage.Asset);
             t.strictEqual(asset.assetId, assetInfo.id);
             t.strictEqual(asset.assetType, assetInfo.type);
             t.ok(asset.data.length);

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -67,6 +67,18 @@ test('addWebSource', t => {
 
 test('load', t => {
     const promises = [];
+    const checkAsset = (assetInfo, asset) => {
+        t.type(asset, storage.Asset);
+        t.strictEqual(asset.assetId, assetInfo.id);
+        t.strictEqual(asset.assetType, assetInfo.type);
+        t.ok(asset.data.length);
+
+        if (assetInfo.md5) {
+            const hash = crypto.createHash('md5');
+            hash.update(asset.data);
+            t.strictEqual(hash.digest('hex'), assetInfo.md5);
+        }
+    };
     for (var i = 0; i < testAssets.length; ++i) {
         const assetInfo = testAssets[i];
 
@@ -75,18 +87,7 @@ test('load', t => {
 
         promises.push(promise);
 
-        promise.then(asset => {
-            t.type(asset, storage.Asset);
-            t.strictEqual(asset.assetId, assetInfo.id);
-            t.strictEqual(asset.assetType, assetInfo.type);
-            t.ok(asset.data.length);
-
-            if (assetInfo.md5) {
-                const hash = crypto.createHash('md5');
-                hash.update(asset.data);
-                t.strictEqual(hash.digest('hex'), assetInfo.md5);
-            }
-        });
+        promise.then(asset => checkAsset(assetInfo, asset));
     }
 
     return Promise.all(promises);

--- a/test/unit/load-default-assets.js
+++ b/test/unit/load-default-assets.js
@@ -25,6 +25,16 @@ test('getDefaultAssetId', t => {
 
 test('load', t => {
     const promises = [];
+    const checkAsset = (assetType, id, asset) => {
+        t.type(asset, storage.Asset);
+        t.strictEqual(asset.assetId, id);
+        t.strictEqual(asset.assetType, assetType);
+        t.ok(asset.data.length);
+
+        const hash = crypto.createHash('md5');
+        hash.update(asset.data);
+        t.strictEqual(hash.digest('hex'), id);
+    };
     for (var i = 0; i < defaultAssetTypes.length; ++i) {
         const assetType = defaultAssetTypes[i];
         const id = defaultIds[assetType.name];
@@ -34,16 +44,7 @@ test('load', t => {
 
         promises.push(promise);
 
-        promise.then(asset => {
-            t.type(asset, storage.Asset);
-            t.strictEqual(asset.assetId, id);
-            t.strictEqual(asset.assetType, assetType);
-            t.ok(asset.data.length);
-
-            const hash = crypto.createHash('md5');
-            hash.update(asset.data);
-            t.strictEqual(hash.digest('hex'), id);
-        });
+        promise.then(asset => checkAsset(assetType, id, asset));
     }
 
     return Promise.all(promises);

--- a/test/unit/load-default-assets.js
+++ b/test/unit/load-default-assets.js
@@ -2,11 +2,6 @@ const crypto = require('crypto');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
-const Asset = ScratchStorage.Asset;
-const AssetType = ScratchStorage.AssetType;
-
-const defaultAssetTypes = [AssetType.ImageBitmap, AssetType.ImageVector, AssetType.Sound];
-const defaultIds = {};
 
 var storage;
 test('constructor', t => {
@@ -14,6 +9,9 @@ test('constructor', t => {
     t.type(storage, ScratchStorage);
     t.end();
 });
+
+const defaultAssetTypes = [storage.AssetType.ImageBitmap, storage.AssetType.ImageVector, storage.AssetType.Sound];
+const defaultIds = {};
 
 test('getDefaultAssetId', t => {
     for (var i = 0; i < defaultAssetTypes.length; ++i) {
@@ -37,7 +35,7 @@ test('load', t => {
         promises.push(promise);
 
         promise.then(asset => {
-            t.type(asset, Asset);
+            t.type(asset, storage.Asset);
             t.strictEqual(asset.assetId, id);
             t.strictEqual(asset.assetType, assetType);
             t.ok(asset.data.length);


### PR DESCRIPTION
### Proposed Changes

Add `Asset` and `AssetType` to the `ScratchStorage` prototype, so that they're available on `ScratchStorage` instances. Also, deprecate accessing `Asset` or `AssetType` through `ScratchStorage` itself. These can be removed in a later change, once all consumers update to the new method of access.

The tests have also been updated to satisfy `eslint`'s `no-loop-func` rule.

### Reason for Changes

This allows consumers of this module to access `Asset` and `AssetType` without having to `require` the storage module itself. Specifically, this makes it possible to avoid building the `scratch-storage` module into both `scratch-vm` and `scratch-gui` separately.

### Test Coverage

The existing tests have been altered to access `Asset` and `AssetType` through a `ScratchStorage` instance.