### PR TITLE
Prepare to use semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ install:
   - npm update
   - npm prune
 script:
-  - npm run test
+  - npm run lint
   - npm run build
+  - npm run tap
 after_script:
 - |
   # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ cache:
 node_js:
   - "4"
   - "node"
-before_install:
+install:
   - npm update
   - npm prune
+script:
+  - npm run test
+  - npm run build
 after_script:
 - |
   # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
-language: node_js
-node_js:
-- "4"
-- "node"
 sudo: false
+language: node_js
 cache:
   directories:
-  - node_modules
-install:
-- npm install
-- npm update
+    - node_modules
+node_js:
+  - "4"
+  - "node"
+before_install:
+  - npm update
+  - npm prune
 after_script:
 - |
   # RELEASE_BRANCHES and NPM_TOKEN defined in Travis settings panel
@@ -23,9 +23,5 @@ after_script:
     # Don't release on PR builds
     $TRAVIS_PULL_REQUEST = "false"
   ]]; then
-    # Authenticate NPM
-    echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-    # Set version to timestamp
-    npm --no-git-tag-version version $($(npm bin)/json -f package.json version)-prerelease.$(date +%s)
-    npm publish
+    npm run semantic-release
   fi

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "scratch-storage",
-  "version": "0.0.1",
+  "version": "0.0.0-development",
   "description": "Load and store project and asset files for Scratch 3.0",
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/LLK/scratch-storage#readme",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/LLK/scratch-storage.git"
+    "url": "https://github.com/LLK/scratch-storage.git"
   },
   "main": "./dist/node/scratch-storage.js",
   "scripts": {
@@ -19,7 +19,8 @@
     "tap-unit": "./node_modules/.bin/tap ./test/unit/*.js",
     "test": "npm run lint && npm run tap-unit && npm run tap-integration",
     "version": "./node_modules/.bin/json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
-    "watch": "./node_modules/.bin/webpack --progress --colors --watch"
+    "watch": "./node_modules/.bin/webpack --progress --colors --watch",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "devDependencies": {
     "babel-core": "6.22.1",
@@ -28,6 +29,7 @@
     "babel-polyfill": "6.22.0",
     "babel-preset-es2015": "6.22.0",
     "binary-loader": "0.0.1",
+    "cz-conventional-changelog": "^2.0.0",
     "debug": "2.6.0",
     "eslint": "3.14.1",
     "eslint-config-scratch": "3.1.0",
@@ -37,9 +39,18 @@
     "json": "^9.0.4",
     "json-loader": "0.5.4",
     "localforage": "1.5.0",
+    "semantic-release": "^6.3.2",
     "tap": "8.0.1",
     "text-encoding": "0.6.4",
     "travis-after-all": "^1.4.4",
     "webpack": "2.2.1"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  },
+  "release": {
+    "branch": "develop"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "build": "./node_modules/.bin/webpack --progress --colors --bail",
     "coverage": "./node_modules/.bin/tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",
     "lint": "./node_modules/.bin/eslint .",
-    "prepublish": "npm run build",
-    "prepublish-watch": "npm run watch",
     "tap-integration": "./node_modules/.bin/tap ./test/integration/*.js",
     "tap-unit": "./node_modules/.bin/tap ./test/unit/*.js",
     "test": "npm run lint && npm run tap-unit && npm run tap-integration",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "./node_modules/.bin/eslint .",
     "tap-integration": "./node_modules/.bin/tap ./test/integration/*.js",
     "tap-unit": "./node_modules/.bin/tap ./test/unit/*.js",
-    "test": "npm run lint && npm run tap-unit && npm run tap-integration",
+    "tap": "npm run tap-unit && npm run tap-integration",
+    "test": "npm run lint && npm run tap",
     "version": "./node_modules/.bin/json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
     "watch": "./node_modules/.bin/webpack --progress --colors --watch",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"


### PR DESCRIPTION
### Proposed Changes

These changes will set us up to publish new versions according to the [Semantic Versioning](http://semver.org/) specification.

Specific changes:
- Install & configure `semantic-release` and `commitizen`.
- Configure Travis CI to use `semantic-release`.

### Reason for Changes

The `semantic-release` package will help us update our version number correctly; `commitizen` will help make commit messages that `semantic-release` will be able to parse.
