### PR TITLE
Cache loaded assets with BuiltinHelper

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -14,6 +14,14 @@ class Asset {
 
         /** @type {string} */
         this.assetId = assetId;
+
+        this.setData(data, dataFormat);
+
+        /** @type {Asset[]} */
+        this.dependencies = [];
+    }
+
+    setData (data, dataFormat) {
         if (data && !dataFormat) {
             throw new Error('Data provided without specifying its format');
         }
@@ -23,9 +31,6 @@ class Asset {
 
         /** @type {Buffer} */
         this.data = data;
-
-        /** @type {Asset[]} */
-        this.dependencies = [];
     }
 
     /**
@@ -41,12 +46,8 @@ class Asset {
      * @returns {string} - A data URI representing the asset's data.
      */
     encodeDataURI (contentType) {
-        return [
-            'data:',
-            contentType || this.assetType.contentType,
-            ';base64,',
-            this.data.toString('base64')
-        ].join('');
+        contentType = contentType || this.assetType.contentType;
+        return `data:${contentType};base64,${this.data.toString('base64')}`;
     }
 }
 

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -1,5 +1,15 @@
 const TextDecoder = require('text-encoding').TextDecoder;
 
+const memoizedToString = (function () {
+    const strings = {};
+    return (assetId, data) => {
+        if (!strings.hasOwnProperty(assetId)) {
+            strings[assetId] = data.toString('base64');
+        }
+        return strings[assetId];
+    };
+}());
+
 class Asset {
     /**
      * Construct an Asset.
@@ -47,7 +57,7 @@ class Asset {
      */
     encodeDataURI (contentType) {
         contentType = contentType || this.assetType.contentType;
-        return `data:${contentType};base64,${this.data.toString('base64')}`;
+        return `data:${contentType};base64,${memoizedToString(this.assetId, this.data)}`;
     }
 }
 

--- a/src/AssetType.js
+++ b/src/AssetType.js
@@ -8,32 +8,38 @@ const DataFormat = require('./DataFormat');
  * @property {string} name - The human-readable name of this asset type.
  * @property {DataFormat} runtimeFormat - The format used for runtime, in-memory storage of this asset. For example, a
  *     project stored in SB2 format on disk will be returned as JSON when loaded into memory.
+ * @property {boolean} immutable - Indicates if the asset id is determined by the asset content.
  */
 const AssetType = {
     ImageBitmap: {
         contentType: 'image/png',
         name: 'ImageBitmap',
-        runtimeFormat: DataFormat.PNG
+        runtimeFormat: DataFormat.PNG,
+        immutable: true
     },
     ImageVector: {
         contentType: 'image/svg+xml',
         name: 'ImageVector',
-        runtimeFormat: DataFormat.SVG
+        runtimeFormat: DataFormat.SVG,
+        immutable: true
     },
     Project: {
         contentType: 'application/json',
         name: 'Project',
-        runtimeFormat: DataFormat.JSON
+        runtimeFormat: DataFormat.JSON,
+        immutable: false
     },
     Sound: {
         contentType: 'audio/x-wav',
         name: 'Sound',
-        runtimeFormat: DataFormat.WAV
+        runtimeFormat: DataFormat.WAV,
+        immutable: true
     },
     Sprite: {
         contentType: 'application/json',
         name: 'Sprite',
-        runtimeFormat: DataFormat.JSON
+        runtimeFormat: DataFormat.JSON,
+        immutable: true
     }
 };
 

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -70,6 +70,12 @@ class BuiltinHelper extends Helper {
         }
     }
 
+
+    /**
+     * Synchronously fetch a cached asset for a given asset id. Returns null if not found.
+     * @param {string} assetId - The id for the asset to fetch.
+     * @returns {?Asset} The asset for assetId, if it exists.
+     */
     get (assetId) {
         let asset = null;
         if (this.assets.hasOwnProperty(assetId)) {
@@ -80,6 +86,14 @@ class BuiltinHelper extends Helper {
         return asset;
     }
 
+    /**
+     * Cache an asset for future lookups by ID.
+     * @param {AssetType} assetType - The type of the asset to cache.
+     * @param {DataFormat} dataFormat - The dataFormat of the data for the cached asset.
+     * @param {Buffer} data - The data for the cached asset.
+     * @param {string} id - The id for the cached asset.
+     * @returns {string} The calculated id of the cached asset, or the supplied id if the asset is mutable.
+     */
     cache (assetType, dataFormat, data, id) {
         if (!dataFormat) throw new Error('Data cached without specifying its format');
         if (id) {

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -54,9 +54,9 @@ class BuiltinHelper extends Helper {
          */
         this.assets = {};
 
-        BuiltinAssets.forEach(
-            assetRecord => this.cache(assetRecord.type, assetRecord.format, assetRecord.data, assetRecord.id)
-        );
+        BuiltinAssets.forEach(assetRecord => {
+            assetRecord.id = this.cache(assetRecord.type, assetRecord.format, assetRecord.data, assetRecord.id);
+        });
     }
 
     /**

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -54,22 +54,9 @@ class BuiltinHelper extends Helper {
          */
         this.assets = {};
 
-        const numAssets = BuiltinAssets.length;
-        for (let assetIndex = 0; assetIndex < numAssets; ++assetIndex) {
-            const assetRecord = BuiltinAssets[assetIndex];
-            const typeName = assetRecord.type.name;
-
-            /** @type {AssetIdMap} */
-            const typeBucket = this.assets[typeName] = this.assets[typeName] || {};
-
-            if (!assetRecord.id) {
-                const hash = crypto.createHash('md5');
-                hash.update(assetRecord.data);
-                assetRecord.id = hash.digest('hex');
-            }
-
-            typeBucket[assetRecord.id] = assetRecord;
-        }
+        BuiltinAssets.forEach(
+            assetRecord => this.cache(assetRecord.type, assetRecord.format, assetRecord.data, assetRecord.id)
+        );
     }
 
     /**
@@ -83,6 +70,34 @@ class BuiltinHelper extends Helper {
         }
     }
 
+    get (assetId) {
+        let asset = null;
+        if (this.assets.hasOwnProperty(assetId)) {
+            /** @type{BuiltinAssetRecord} */
+            const assetRecord = this.assets[assetId];
+            asset = new Asset(assetRecord.type, assetRecord.id, assetRecord.format, assetRecord.data);
+        }
+        return asset;
+    }
+
+    cache (assetType, dataFormat, data, id) {
+        if (!dataFormat) throw new Error('Data cached without specifying its format');
+        if (id) {
+            if (this.assets.hasOwnProperty(id)) return id;
+        } else {
+            const hash = crypto.createHash('md5');
+            hash.update(data);
+            id = hash.digest('hex');
+        }
+        this.assets[id] = {
+            type: assetType,
+            format: dataFormat,
+            id: id,
+            data: data
+        };
+        return id;
+    }
+
     /**
      * Fetch an asset but don't process dependencies.
      * @param {AssetType} assetType - The type of asset to fetch.
@@ -90,16 +105,7 @@ class BuiltinHelper extends Helper {
      * @return {Promise.<Asset>} A promise for the contents of the asset.
      */
     load (assetType, assetId) {
-        let asset = null;
-        if (this.assets.hasOwnProperty(assetType.name)) {
-            const typeBucket = this.assets[assetType.name];
-            if (typeBucket.hasOwnProperty(assetId)) {
-                /** @type{BuiltinAssetRecord} */
-                const assetRecord = typeBucket[assetId];
-                asset = new Asset(assetRecord.type, assetRecord.id, assetRecord.format, assetRecord.data);
-            }
-        }
-        return Promise.resolve(asset);
+        return Promise.resolve(this.get(assetId));
     }
 }
 

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -9,7 +9,7 @@ const Helper = require('./Helper');
  * @typedef {object} BuiltinAssetRecord
  * @property {AssetType} type - The type of the asset.
  * @property {DataFormat} format - The format of the asset's data.
- * @property {string} id - The asset's unique ID.
+ * @property {?string} id - The asset's unique ID.
  * @property {Buffer} data - The asset's data.
  */
 
@@ -97,8 +97,8 @@ class BuiltinHelper extends Helper {
     cache (assetType, dataFormat, data, id) {
         if (!dataFormat) throw new Error('Data cached without specifying its format');
         if (id) {
-            if (this.assets.hasOwnProperty(id)) return id;
-        } else {
+            if (this.assets.hasOwnProperty(id) && assetType.immutable) return id;
+        } else if (assetType.immutable) {
             const hash = crypto.createHash('md5');
             hash.update(data);
             id = hash.digest('hex');

--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -117,11 +117,12 @@ class ScratchStorage {
                                     tryNextHelper();
                                 } else {
                                     // TODO? this.localHelper.cache(assetType, assetId, asset);
-                                    if (helper !== this.builtinHelper) {
+                                    if (helper !== this.builtinHelper && assetType.immutable) {
                                         asset.assetId = this.builtinHelper.cache(
                                             assetType,
                                             asset.dataFormat,
-                                            asset.data
+                                            asset.data,
+                                            assetId
                                         );
                                     }
                                     // Note that other attempts may have caused errors, effectively suppressed here.

--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -49,6 +49,11 @@ class ScratchStorage {
         return AssetType;
     }
 
+    /**
+     * Synchronously fetch a cached asset from built-in storage. Assets are cached when they are loaded.
+     * @param {string} assetId - The id of the asset to fetch.
+     * @returns {?Asset} The asset, if it exists.
+     */
     get (assetId) {
         return this.builtinHelper.get(assetId);
     }

--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -49,6 +49,10 @@ class ScratchStorage {
         return AssetType;
     }
 
+    get (assetId) {
+        return this.builtinHelper.get(assetId);
+    }
+
     /**
      * Register a web-based source for assets. Sources will be checked in order of registration.
      * @param {Array.<AssetType>} types - The types of asset provided by this source.
@@ -100,13 +104,21 @@ class ScratchStorage {
         return new Promise((fulfill, reject) => {
             const tryNextHelper = () => {
                 if (helperIndex < helpers.length) {
-                    helpers[helperIndex++].load(assetType, assetId)
+                    const helper = helpers[helperIndex++];
+                    helper.load(assetType, assetId)
                         .then(
                             asset => {
                                 if (asset === null) {
                                     tryNextHelper();
                                 } else {
                                     // TODO? this.localHelper.cache(assetType, assetId, asset);
+                                    if (helper !== this.builtinHelper) {
+                                        asset.assetId = this.builtinHelper.cache(
+                                            assetType,
+                                            asset.dataFormat,
+                                            asset.data
+                                        );
+                                    }
                                     // Note that other attempts may have caused errors, effectively suppressed here.
                                     fulfill(asset);
                                 }

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -77,7 +77,7 @@ class WebHelper extends Helper {
                                 }
                                 tryNextSource();
                             } else {
-                                asset.data = response.body;
+                                asset.setData(response.body, assetType.runtimeFormat);
                                 fulfill(asset);
                             }
                         },


### PR DESCRIPTION
### Resolves

Part of the resolution for:
- https://github.com/LLK/scratch-vm/issues/194
- https://github.com/LLK/scratch-vm/issues/550
- https://github.com/LLK/scratch-gui/issues/329

### Proposed Changes

- Add `cache` method to BuiltinHelper, to store retrieved assets
- Cache assets retrieved with other helpers with BuiltinHelper
- Flatten the BuiltinHelper cache structure, so only the md5 is needed to retrieve an asset. A collision between two types would be interesting but unlikely
- Add a synchronous `get` method to ScratchStorage that passes through to the BuiltinHelper for cached assets
- Fix WebHelper, so it sets the dataFormat on the Asset it returns
- Memoize base64 encoding of asset data by asset id

### Reason for Changes

This allows us to stop passing around asset data as a part of VM state, by storing the data in the storage instance.  Instead, consumers of the data only need an asset ID, and can retrieve it from the storage engine when required.
