### PR TITLE
Make `got` an external dependency for the Node build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "watch": "./node_modules/.bin/webpack --progress --colors --watch",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
+  "dependencies": {
+    "got": "5.7.1"
+  },
   "devDependencies": {
     "babel-core": "6.22.1",
     "babel-eslint": "7.1.1",
@@ -34,7 +37,6 @@
     "eslint-config-scratch": "3.1.0",
     "eslint-plugin-react": "6.9.0",
     "file-loader": "0.9.0",
-    "got": "5.7.1",
     "json": "^9.0.4",
     "json-loader": "0.5.4",
     "localforage": "1.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,9 @@ module.exports = [
         entry: {
             'scratch-storage': './src/index.js'
         },
+        externals: {
+            got: 'got'
+        },
         output: {
             library: 'ScratchStorage',
             libraryTarget: 'commonjs2',


### PR DESCRIPTION
### Resolves

Issue https://github.com/LLK/scratch-storage/issues/14.

### Proposed Changes

Move `got` from a "devDependency" to a "dependency".  Mark it as external for the Node.js webpack build.

### Reason for Changes

Making `got` an explicit dependency lets the consuming project control whether `got` is built for a node or web target.

### Test Coverage

I struggled a bit getting solid test coverage of this, or even a standalone repro case.  It only happens when for `import Storage from 'scratch-storage'` is used in a client-side project.

I wrote a sample test case to verify gzipped assets can be loaded, but `npm test` runs via Node.js it doesn't repro the issue 😕.  Happy to add appropriate coverage if you know of a better approach!

```js
const crypto = require('crypto');
const test = require('tap').test;
const zlib = require('zlib');
const http = require('http');

global.self = {};
require('../../dist/web/scratch-storage');

const port = 8071;
const svgData = `<?xml version="1.0"?>
<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
  <circle fill="#F00" cx="50" cy="50" r="30"/>
</svg>
`;

test('loadGzippedAsset', t => {
    const server = http.createServer((request, response) => {
        const raw = zlib.gzipSync(svgData);
        response.writeHead(200, {'Content-Encoding': 'gzip'});
        response.end(raw);
    }).listen(port);

    const storage = new self.Scratch.Storage();
    storage.addWebSource(
        [storage.AssetType.ImageVector],
        () => `http://localhost:${port}`
    );

    const assetType = storage.AssetType.ImageVector;
    const id = '8e768a5a5a01891b05c01c9ca15eb6aa';

    const promise = storage.load(assetType, id);
    t.type(promise, 'Promise');

    promise.then(asset => {
        t.type(asset, storage.Asset);
        t.strictEqual(asset.assetType, assetType);
        t.strictEqual(asset.assetId, id);

        const hash = crypto.createHash('md5');
        hash.update(asset.data);
        t.strictEqual(hash.digest('hex'), id);

        server.close();
    });

    return promise;
});
```
