### PR TITLE
Use base64 package instead of toString('base64')

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-loader": "6.2.10",
     "babel-polyfill": "6.22.0",
     "babel-preset-es2015": "6.22.0",
+    "base64-js": "1.2.1",
     "binary-loader": "0.0.1",
     "cz-conventional-changelog": "^2.0.0",
     "debug": "2.6.0",

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -1,10 +1,11 @@
 const TextDecoder = require('text-encoding').TextDecoder;
+const base64js = require('base64-js');
 
 const memoizedToString = (function () {
     const strings = {};
     return (assetId, data) => {
         if (!strings.hasOwnProperty(assetId)) {
-            strings[assetId] = data.toString('base64');
+            strings[assetId] = base64js.fromByteArray(data);
         }
         return strings[assetId];
     };


### PR DESCRIPTION
`toString` does not support arguments in the browser. Only in node (and apparently things got by got) allow an encoding to be passed to `toString`. 

This problem comes up when you try to use the `cache` function, adding your own data to storage instead of getting it from a URL. When it comes out of a URL (through `got`), a new `toString` function is overridden on the `Uint8Array` to make it act like a node `Buffer` object. When you try to cache your own `Uint8Array`, without that fancy toString, it fails to come back out correctly when you call `encodeDataURI`. 

_Aside: what the hell `got`?! Why are you overriding built-in methods of primitive JS objects. Very not cool. Damn near impossible to debug._ 

I added a new dependency that does this base64 conversion explicitly. 
