### PR TITLE
replace 'got' with 'nets' and fix the 'web+commonjs2' and 'node+commonjs2' targets in webpack.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/LLK/scratch-storage.git"
   },
-  "main": "./dist/node/scratch-storage.js",
+  "main": "./dist/web_commonjs2/scratch-storage.js",
   "scripts": {
     "build": "./node_modules/.bin/webpack --progress --colors --bail",
     "coverage": "./node_modules/.bin/tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",
@@ -38,6 +38,7 @@
     "json": "^9.0.4",
     "json-loader": "0.5.4",
     "localforage": "1.5.0",
+    "nets": "^3.2.0",
     "semantic-release": "^6.3.2",
     "tap": "8.0.1",
     "text-encoding": "0.6.4",

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -68,7 +68,7 @@ class WebHelper extends Helper {
                 if (urlFunction) {
                     const url = urlFunction(asset);
 
-                    nets({ url: url }, function(err, resp, body) {
+                    nets({url: url}, (err, resp, body) => {
                         // body is a Buffer
                         if (err) {
                             tryNextSource();

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -1,4 +1,4 @@
-const got = require('got');
+const nets = require('nets');
 
 const Asset = require('./Asset');
 const Helper = require('./Helper');
@@ -66,26 +66,17 @@ class WebHelper extends Helper {
                 }
 
                 if (urlFunction) {
-                    const options = {
-                        encoding: null // return body as Buffer
-                    };
                     const url = urlFunction(asset);
-                    got(url, options).then(
-                        response => {
-                            if (response.status < 200 || response.status >= 300) {
-                                if (response.status !== 404) {
-                                    errors.push({url: url, result: response});
-                                }
-                                tryNextSource();
-                            } else {
-                                asset.setData(response.body, dataFormat);
-                                fulfill(asset);
-                            }
-                        },
-                        error => {
-                            errors.push({url: url, result: error});
+
+                    nets({ url: url }, function(err, resp, body) {
+                        // body is a Buffer
+                        if (err) {
                             tryNextSource();
-                        });
+                        } else {
+                            asset.setData(body, dataFormat);
+                            fulfill(asset);
+                        }
+                    });
                 } else if (errors.length > 0) {
                     reject(errors);
                 } else {

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const test = require('tap').test;
 
-const ScratchStorage = require('../../dist/node/scratch-storage');
+const ScratchStorage = require('../../dist/node_commonjs2/scratch-storage');
 
 var storage;
 test('constructor', t => {

--- a/test/unit/load-default-assets.js
+++ b/test/unit/load-default-assets.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const test = require('tap').test;
 
-const ScratchStorage = require('../../dist/node/scratch-storage');
+const ScratchStorage = require('../../dist/node_commonjs2/scratch-storage');
 
 var storage;
 test('constructor', t => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const base = {
 };
 
 module.exports = [
-    // Web-compatible
+    // Web + UMD
     Object.assign({}, base, {
         target: 'web',
         entry: {
@@ -36,11 +36,25 @@ module.exports = [
         },
         output: {
             path: __dirname,
-            filename: 'dist/web/[name].js'
+            filename: 'dist/web_umd/[name].js'
         }
     }),
 
-    // Node-compatible
+    // Web + commonjs2
+    Object.assign({}, base, {
+        target: 'web',
+        entry: {
+            'scratch-storage': './src/index.js'
+        },
+        output: {
+            library: 'ScratchStorage',
+            libraryTarget: 'commonjs2',
+            path: __dirname,
+            filename: 'dist/web_commonjs2/[name].js'
+        }
+    }),
+
+    // Node + commonjs2
     Object.assign({}, base, {
         target: 'node',
         entry: {
@@ -50,7 +64,7 @@ module.exports = [
             library: 'ScratchStorage',
             libraryTarget: 'commonjs2',
             path: __dirname,
-            filename: 'dist/node/[name].js'
+            filename: 'dist/node_commonjs2/[name].js'
         }
     })
 ];


### PR DESCRIPTION

### Resolves

https://github.com/LLK/scratch-storage/issues/16

### Proposed Changes

1. replace 'got' with 'nets'
2. standardize the targets in webpack.config.js
web+umd
web+commonjs2
node+commonjs2
set 'web+commonjs2' as default 'main' filed in package.json

### Reason for Changes

See the issue for details.

### Test Coverage

Tested in 'scratch-gui' (web+commonjs2) and 'npm run tap' in 'scratch-storage' (node + commonjs2)