### PR TITLE
Replace crypto with js-md5 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-config-scratch": "3.1.0",
     "eslint-plugin-react": "6.9.0",
     "file-loader": "0.9.0",
+    "js-md5": "0.6.1",
     "json": "^9.0.4",
     "json-loader": "0.5.4",
     "localforage": "1.5.0",

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const md5 = require('js-md5');
 
 const Asset = require('./Asset');
 const AssetType = require('./AssetType');
@@ -99,9 +99,7 @@ class BuiltinHelper extends Helper {
         if (id) {
             if (this.assets.hasOwnProperty(id) && assetType.immutable) return id;
         } else if (assetType.immutable) {
-            const hash = crypto.createHash('md5');
-            hash.update(data);
-            id = hash.digest('hex');
+            id = md5(data);
         }
         this.assets[id] = {
             type: assetType,

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const md5 = require('js-md5');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
@@ -93,9 +93,7 @@ test('load', t => {
         t.ok(asset.data.length);
 
         if (assetInfo.md5) {
-            const hash = crypto.createHash('md5');
-            hash.update(asset.data);
-            t.strictEqual(hash.digest('hex'), assetInfo.md5);
+            t.strictEqual(md5(asset.data), assetInfo.md5);
         }
     };
     for (var i = 0; i < testAssets.length; ++i) {

--- a/test/unit/load-default-assets.js
+++ b/test/unit/load-default-assets.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const md5 = require('js-md5');
 const test = require('tap').test;
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
@@ -30,10 +30,7 @@ test('load', t => {
         t.strictEqual(asset.assetId, id);
         t.strictEqual(asset.assetType, assetType);
         t.ok(asset.data.length);
-
-        const hash = crypto.createHash('md5');
-        hash.update(asset.data);
-        t.strictEqual(hash.digest('hex'), id);
+        t.strictEqual(md5(asset.data), id);
     };
     for (var i = 0; i < defaultAssetTypes.length; ++i) {
         const assetType = defaultAssetTypes[i];


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolve https://github.com/LLK/scratch-storage/issues/18 by replacing crypto with js-md5 package

### Proposed Changes

_Describe what this Pull Request does_

Instead of the local node module `crypto`, which doesn't play well on the web, use a browser compatible package. 

### Reason for Changes

_Explain why these changes should be made_

Wasn't able to use `builtInHelper.cache` from outside the storage package. 

### Test Coverage

_Please show how you have added tests to cover your changes_

Updated the tests, all passing. 