### PR TITLE
Expose builtinHelper.cache to storage API

### DIFF
--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -69,6 +69,18 @@ class ScratchStorage {
     }
 
     /**
+     * Cache an asset for future lookups by ID.
+     * @param {AssetType} assetType - The type of the asset to cache.
+     * @param {DataFormat} dataFormat - The dataFormat of the data for the cached asset.
+     * @param {Buffer} data - The data for the cached asset.
+     * @param {string} id - The id for the cached asset.
+     * @returns {string} The calculated id of the cached asset, or the supplied id if the asset is mutable.
+     */
+    cache (assetType, dataFormat, data, id) {
+        return this.builtinHelper.cache(assetType, dataFormat, data, id);
+    }
+
+    /**
      * Register a web-based source for assets. Sources will be checked in order of registration.
      * @param {Array.<AssetType>} types - The types of asset provided by this source.
      * @param {UrlFunction} urlFunction - A function which computes a URL from an Asset.


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Towards https://github.com/LLK/scratch-gui/issues/617

### Proposed Changes

_Describe what this Pull Request does_
Add a `cache` method to the top level storage API. This is a simple pass-through to `builtinHelper.cache`. That is, assets cached this way are cached in memory.

### Reason for Changes

_Explain why these changes should be made_
This allows locally pre-caching assets, to avoid subsequent network requests. I should note that this is a hack until we have real caching with local storage or similar.
