### PR TITLE
Add a method to encode text into asset data

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -1,4 +1,5 @@
 const TextDecoder = require('text-encoding').TextDecoder;
+const TextEncoder = require('text-encoding').TextEncoder;
 const base64js = require('base64-js');
 
 const memoizedToString = (function () {
@@ -50,6 +51,16 @@ class Asset {
     decodeText () {
         const decoder = new TextDecoder();
         return decoder.decode(this.data);
+    }
+
+    /**
+     * Same as `setData` but encodes text first.
+     * @param {string} data - the text data to encode and store.
+     * @param {DataFormat} dataFormat - the format of the data (DataFormat.SVG for example).
+     */
+    encodeTextData (data, dataFormat) {
+        const encoder = new TextEncoder();
+        this.setData(encoder.encode(data), dataFormat);
     }
 
     /**


### PR DESCRIPTION
### Resolves

This is a supporting change for LLK/scratch-paint#206 and LLK/scratch-gui#762

### Proposed Changes

This new method encodes JS text into UTF-8 then sets the asset's data to the encoded text. Effectively, this is a version of the existing `setData` function design for text data encoded in UTF-8.

### Reason for Changes

The `setData` function already allows a binary asset's content to be modified at runtime. This change allows that with text assets too. The current WIP for LLK/scratch-paint#206 and LLK/scratch-gui#762 uses this to "fix up" a Scratch 2.0-style SVG immediately after importing it, rather than at render time.
