### PR TITLE
Use commitlint to ensure the creation of new versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - npm update
   - npm prune
 script:
+  - commitlint-travis
   - npm run lint
   - npm run build
   - npm run tap

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@commitlint/cli": "6.1.0",
     "@commitlint/config-conventional": "6.1.0",
+    "@commitlint/travis-cli": "6.1.0",
     "babel-core": "6.22.1",
     "babel-eslint": "7.1.1",
     "babel-loader": "6.2.10",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "webpack --progress --colors --bail",
     "coverage": "tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint .",
     "tap-integration": "tap ./test/integration/*.js",
     "tap-unit": "tap ./test/unit/*.js",
@@ -23,6 +24,8 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "devDependencies": {
+    "@commitlint/cli": "6.1.0",
+    "@commitlint/config-conventional": "6.1.0",
     "babel-core": "6.22.1",
     "babel-eslint": "7.1.1",
     "babel-loader": "6.2.10",
@@ -36,6 +39,7 @@
     "eslint-config-scratch": "3.1.0",
     "eslint-plugin-react": "6.9.0",
     "file-loader": "0.9.0",
+    "husky": "0.14.3",
     "js-md5": "0.6.1",
     "json": "^9.0.4",
     "json-loader": "0.5.4",


### PR DESCRIPTION
This is an experiment to see if it would help to enforce commit message formatting through a linting tool.

On `npm install`, a git commit hook is created which checks that the format of your commit message conforms with the conventional changelog. If your message is malformatted, you're presented with a nice message that lets you know the issue.

This also includes a tool to do the same checking on Travis, for cases where a commit is created outside of an environment with commit hooks.  Supposedly this will lint all the commits for a PR — I guess we'll find out!