### PR TITLE
chore(build): replace babel-preset-es2015 with babel-preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-eslint": "7.1.1",
     "babel-loader": "6.2.10",
     "babel-polyfill": "6.22.0",
-    "babel-preset-es2015": "6.22.0",
+    "babel-preset-env": "^1.6.1",
     "base64-js": "1.2.1",
     "binary-loader": "0.0.1",
     "cz-conventional-changelog": "^2.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const base = {
                 test: /\.js$/,
                 loader: 'babel-loader',
                 options: {
-                    presets: ['es2015']
+                    presets: [['env', {targets: {browsers: ['last 3 versions', 'Safari >= 8', 'iOS >= 8']}}]]
                 }
             }
         ]


### PR DESCRIPTION
### Proposed Changes

Replace babel-preset-es2015 with babel-preset-env

### Reason for Changes

Sibling of https://github.com/LLK/scratch-vm/pull/1112
