### PR TITLE
fix: allow asset url function to indicate skipping

### DIFF
--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -67,6 +67,10 @@ class WebHelper extends Helper {
 
                 if (urlFunction) {
                     const url = urlFunction(asset);
+                    if (url === false) {
+                        tryNextSource();
+                        return;
+                    }
 
                     nets({url: url}, (err, resp, body) => {
                         // body is a Buffer


### PR DESCRIPTION
### Resolves

Is connected to #31 but I did not create an issue for this particular change.

### Proposed Changes

Whenever an `assetUrl` returns `false` the `WebHelper` tries the next source.

### Reason for Changes

If there are multiple web sources, the url function may want to indicate whether the current asset is available in its source, based on the asset. While sources are already filtered by asset type, there may be different properties that determine if a source is applicable.
In our case, we use a special prefix on some projects to indicate a special source (like a special S3 location). The source will always be the first source, so we can be sure the prefixed projects are always loaded from the right source. But if the prefix is missing the url function should be able to indicate a skip by returning false. Throwing an error is not handled and results in a failure of the app.

### Test Coverage

Will add, if wanted.
