### PR TITLE
Small fixes to #41

### DIFF
--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -155,7 +155,8 @@ class WebHelper extends Helper {
             }
             return nets(Object.assign({
                 body: data,
-                method: method
+                method: method,
+                encoding: undefined // eslint-disable-line no-undefined
             }, reqConfig), (err, resp, body) => {
                 if (err || Math.floor(resp.statusCode / 100) !== 2) {
                     return reject(err || resp.statusCode);

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -162,7 +162,7 @@ class WebHelper extends Helper {
                     return reject(err || resp.statusCode);
                 }
                 return resolve(Object.assign({
-                    id: body['content-name']
+                    id: body['content-name'] || assetId
                 }, body));
             });
         });


### PR DESCRIPTION
This is cleanup for #41, added during integration.

`nets` always returns an arraybuffer unless you give it the option `encoding: undefined`(??) So do that, so we get parsed JSON back.

Also return the asset id even if the response wouldn't return it as a part of a `put` request. I had this when we paired on it @cwillisf, but somehow it went missing.