### PR TITLE
fix: use js implemented encoding APIs if unavailable

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -1,5 +1,17 @@
-const TextDecoder = require('text-encoding').TextDecoder;
-const TextEncoder = require('text-encoding').TextEncoder;
+// Use JS implemented TextDecoder and TextEncoder if it is not provided by the
+// browser.
+let _TextDecoder;
+let _TextEncoder;
+const encoding = require('text-encoding');
+if (typeof TextDecoder === 'undefined' || typeof TextEncoder === 'undefined') {
+    _TextDecoder = encoding.TextDecoder;
+    _TextEncoder = encoding.TextEncoder;
+} else {
+    /* global TextDecoder TextEncoder */
+    _TextDecoder = TextDecoder;
+    _TextEncoder = TextEncoder;
+}
+
 const base64js = require('base64-js');
 
 const memoizedToString = (function () {
@@ -49,7 +61,7 @@ class Asset {
      * @returns {string} - This asset's data, decoded as text.
      */
     decodeText () {
-        const decoder = new TextDecoder();
+        const decoder = new _TextDecoder();
         return decoder.decode(this.data);
     }
 
@@ -59,7 +71,7 @@ class Asset {
      * @param {DataFormat} dataFormat - the format of the data (DataFormat.SVG for example).
      */
     encodeTextData (data, dataFormat) {
-        const encoder = new TextEncoder();
+        const encoder = new _TextEncoder();
         this.setData(encoder.encode(data), dataFormat);
     }
 


### PR DESCRIPTION
### Resolves

Improves performance where binary buffers are decoded into utf8 or utf8 is encoded into binary. This improves general VM loading time and GUI uses of decoding buffers into strings like decoding to render SVG in the paint editor and decoding SVG to render in the sprite item selectors.

### Proposed Changes

Use browser implemented TextDecoder and TextEncoder when available. Otherwise use JS implemented TextDecoder and TextEncoder.

### Reason for Changes

Chrome >= 38, Firefox >= 20, Safari >= 10.3 and Opera >= 25 provide browser implemented TextDecoder and TextEncoder implementations. These implementations are 2 - 10 times faster than the currently used JavaScript implementation.

### Test Coverage

The improvement can be seen in Chrome with project 247578672 while the paint editor is open on the `cover` sprite.