### PR TITLE
bump webpack-cli to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "travis-after-all": "^1.4.4",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.8.0",
-    "webpack-cli": "^2.0.15"
+    "webpack-cli": "^3.1.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
### Resolves

Update to avoid

> /home/travis/build/LLK/scratch-storage/node_modules/webpack-cli/bin/config-yargs.js:89
> 				describe: optionsSchema.definitions.output.properties.path.description,
> 				                                           ^
> TypeError: Cannot read property 'properties' of undefined
>     at module.exports (/home/travis/build/LLK/scratch-storage/node_modules/webpack-cli/bin/config-yargs.js:89:48)
>     at /home/travis/build/LLK/scratch-storage/node_modules/webpack-cli/bin/webpack.js:60:27
>     at Object.<anonymous> (/home/travis/build/LLK/scratch-storage/node_modules/webpack-cli/bin/webpack.js:515:3)
>     at Module._compile (module.js:653:30)
>     at Object.Module._extensions..js (module.js:664:10)
>     at Module.load (module.js:566:32)
>     at tryModuleLoad (module.js:506:12)
>     at Function.Module._load (module.js:498:3)
>     at Module.require (module.js:597:17)
>     at require (internal/module.js:11:18)

### Proposed Changes

Bump webpack-cli to `^3.1.1`

### Reason for Changes

A version of webpack-cli is experiencing a bug on Travis.
