### PR TITLE
fix: WebHelper returns object with id on project creation

### DIFF
--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -161,9 +161,13 @@ class WebHelper extends Helper {
                 if (err || Math.floor(resp.statusCode / 100) !== 2) {
                     return reject(err || resp.statusCode);
                 }
-                return resolve(Object.assign({
-                    id: body['content-name'] || assetId
-                }, body));
+                const bodyObj = typeof body === 'string' ? JSON.parse(body) : body;
+                return resolve(bodyObj.id ?
+                    body :
+                    Object.assign(bodyObj, {
+                        id: bodyObj['content-name'] || assetId
+                    }
+                ));
             });
         });
     }


### PR DESCRIPTION
At the bottom of WebHelper:store(), the `body` parameter appears to be a JSON string, not a JSON object:

<img width="750" alt="screen shot 2018-10-03 at 9 59 07 pm" src="https://user-images.githubusercontent.com/3431616/46449125-44325980-c758-11e8-8388-647e1f3f49d7.png">

Object.assign does currently convert the string to an object, but it does it character by character:

<img width="458" alt="screen shot 2018-10-03 at 10 00 11 pm" src="https://user-images.githubusercontent.com/3431616/46449185-92dff380-c758-11e8-8670-813f8efe19c2.png">

The code here that was setting the id does succeed in doing that -- as long as the assetId is already set:

(If it's an integer value, setting it succeeds:)
<img width="432" alt="screen shot 2018-10-03 at 10 00 51 pm" src="https://user-images.githubusercontent.com/3431616/46449212-bc991a80-c758-11e8-959d-693dbd470b42.png">

(...but if we're relying on the number being extracted from body, that doesn't work:)
<img width="442" alt="screen shot 2018-10-03 at 10 01 04 pm" src="https://user-images.githubusercontent.com/3431616/46449229-dcc8d980-c758-11e8-9d54-fdab22b4e053.png">

So it seems what we really need to do is to JSON.parse the body -- at least before we try to access its content-name property. 

Existing behavior:
PUT (updating project with id) response:
<img width="670" alt="screen shot 2018-10-03 at 11 00 19 pm" src="https://user-images.githubusercontent.com/3431616/46450742-e35b4f00-c760-11e8-9efb-e115cb5e4a2d.png">

POST (creating new project) response:
<img width="357" alt="screen shot 2018-10-03 at 11 02 06 pm" src="https://user-images.githubusercontent.com/3431616/46450745-e9513000-c760-11e8-9bb6-9ef9554ca12c.png">

Behavior with this PR:
PUT (updating project with id) response:
<img width="382" alt="screen shot 2018-10-03 at 10 46 35 pm" src="https://user-images.githubusercontent.com/3431616/46450775-169dde00-c761-11e8-8692-5da9a69eca92.png">

POST (creating new project) response:
<img width="701" alt="screen shot 2018-10-03 at 10 54 55 pm" src="https://user-images.githubusercontent.com/3431616/46450778-1bfb2880-c761-11e8-9b5b-d0198f6205da.png">

Question: should we just do JSON.parse for all responses? Seems like it should be consistent.