### PR TITLE
fix: heed cache->store API change in BuiltinHelper

### DIFF
--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -63,7 +63,7 @@ class BuiltinHelper extends Helper {
         this.assets = {};
 
         BuiltinAssets.forEach(assetRecord => {
-            assetRecord.id = this.cache(assetRecord.type, assetRecord.format, assetRecord.data, assetRecord.id);
+            assetRecord.id = this.store(assetRecord.type, assetRecord.format, assetRecord.data, assetRecord.id);
         });
     }
 


### PR DESCRIPTION
This was kind of an own goal. If it's deprecated the module itself shouldn't use it!

Stop using BuiltinHelper.cache in BuiltinHelper. Since it's deprecated and we're warning other people to use store instead.
