### PR TITLE
fix(npm): fix update to semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "npm run lint && npm run tap",
     "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
     "watch": "webpack --progress --colors --watch",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "dependencies": {
     "arraybuffer-loader": "^1.0.3",


### PR DESCRIPTION
In #51 I failed to notice that semantic-release was updated, so we needed to update the package.json script for releasing