### PR TITLE
feat(webhelper): parse urlOptions to determine remix, copy params

### DIFF
--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -190,13 +190,14 @@ class ScratchStorage {
      * @param {?DataFormat} [dataFormat] - Optional: load this format instead of the AssetType's default.
      * @param {Buffer} data - Data to store for the asset
      * @param {?string} [assetId] - The ID of the asset to fetch: a project ID, MD5, etc.
+     * @param {?object} urlParams - object of params to add to querystring
      * @return {Promise.<object>} A promise for asset metadata
      */
-    store (assetType, dataFormat, data, assetId) {
+    store (assetType, dataFormat, data, assetId, urlParams) {
         dataFormat = dataFormat || assetType.runtimeFormat;
         return new Promise(
             (resolve, reject) =>
-                this.webHelper.store(assetType, dataFormat, data, assetId)
+                this.webHelper.store(assetType, dataFormat, data, assetId, urlParams)
                     .then(body => {
                         this.builtinHelper.store(assetType, dataFormat, data, body.id);
                         return resolve(body);

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -5,6 +5,25 @@ const log = require('./log');
 const Asset = require('./Asset');
 const Helper = require('./Helper');
 
+// takes a url and adds query string params, maintaining existing ones.
+// note that it url encodes incoming param values.
+const addUrlParams = (url, paramsToAdd) => {
+    if (!paramsToAdd || !Object.keys(paramsToAdd).length) {
+        return url;
+    }
+    const parts = url.split(/[?#]/);
+    const searchParams = (new URL(url)).searchParams;
+    for (const key in paramsToAdd) {
+        searchParams.set(key, paramsToAdd[key]);
+    }
+    const queryString = searchParams.toString();
+    let resultUrl = parts[0];
+    if (queryString && queryString.length) {
+        resultUrl += `?${queryString}`;
+    }
+    return resultUrl;
+};
+
 /**
  * @typedef {function} UrlFunction - A function which computes a URL from asset information.
  * @param {Asset} - The asset for which the URL should be computed.
@@ -127,7 +146,7 @@ class WebHelper extends Helper {
      * @param {?string} assetId - The ID of the asset to fetch: a project ID, MD5, etc.
      * @return {Promise.<object>} A promise for the response from the create or update request
      */
-    store (assetType, dataFormat, data, assetId) {
+    store (assetType, dataFormat, data, assetId, urlParams) {
         const asset = new Asset(assetType, assetId, dataFormat);
         // If we have an asset id, we should update, otherwise create to get an id
         const create = assetId === '' || assetId === null || typeof assetId === 'undefined';
@@ -153,6 +172,7 @@ class WebHelper extends Helper {
                     url: reqConfig
                 };
             }
+            reqConfig.url = addUrlParams(reqConfig.url, urlParams);
             return nets(Object.assign({
                 body: data,
                 method: method,

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -144,6 +144,7 @@ class WebHelper extends Helper {
      * @param {?DataFormat} dataFormat - DataFormat of the data for the stored asset.
      * @param {Buffer} data - The data for the cached asset.
      * @param {?string} assetId - The ID of the asset to fetch: a project ID, MD5, etc.
+     * @param {?object} urlParams - object of params to add to querystring
      * @return {Promise.<object>} A promise for the response from the create or update request
      */
     store (assetType, dataFormat, data, assetId, urlParams) {


### PR DESCRIPTION
For remixing and saving as a copy, we need to correctly query projects and scratchr2 endpoints so as to create projects with references back to parent projects, and with titles that reflect the nature of the new project. This change allows for an object of key-value pairs to be passed, which is parsed into url querystring parameters, keeping any existing querystring parameters intact.

### Resolves

https://github.com/LLK/scratch-gui/issues/3197

