### PR TITLE
fix: load asset content

### DIFF
--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -24,7 +24,7 @@ const DefaultAssets = [
         format: DataFormat.PNG,
         id: null,
         data: new Buffer(
-            require('arraybuffer-loader!./builtins/defaultBitmap.png') // eslint-disable-line global-require
+            require('!arraybuffer-loader!./builtins/defaultBitmap.png') // eslint-disable-line global-require
         )
     },
     {
@@ -32,7 +32,7 @@ const DefaultAssets = [
         format: DataFormat.WAV,
         id: null,
         data: new Buffer(
-            require('arraybuffer-loader!./builtins/defaultSound.wav') // eslint-disable-line global-require
+            require('!arraybuffer-loader!./builtins/defaultSound.wav') // eslint-disable-line global-require
         )
     },
     {
@@ -40,7 +40,7 @@ const DefaultAssets = [
         format: DataFormat.SVG,
         id: null,
         data: new Buffer(
-            require('arraybuffer-loader!./builtins/defaultVector.svg') // eslint-disable-line global-require
+            require('!arraybuffer-loader!./builtins/defaultVector.svg') // eslint-disable-line global-require
         )
     }
 ];


### PR DESCRIPTION
### Resolves

When I tried to use the default SVG asset in scratch-storage's `builtins` folder, I found that the `data` property just returned a string that was the file's path and name. This prevented me from getting the file's contents. 

### Proposed Changes

Disable the Webpack `file-loader` loader for these `require` statements. Webpack will still use the specified `arraybuffer-loader` loader for these files, but not using `file-loader` will give `arraybuffer-loader` the contents of the files rather than a string with the path and name of the file. 