### PR TITLE
fix: set a "clean" flag on assets

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -59,6 +59,10 @@ class Asset {
         this.data = data;
 
         if (generateId) this.assetId = md5(data);
+
+        // Mark as clean only if set is being called without generateId
+        // If a new id is being generated, mark this asset as not clean
+        this.clean = !generateId;
     }
 
     /**

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -92,6 +92,9 @@ test('load', t => {
         t.strictEqual(asset.assetType, assetInfo.type);
         t.ok(asset.data.length);
 
+        // Web assets should come back as clean
+        t.true(asset.clean);
+
         if (assetInfo.md5) {
             t.strictEqual(md5(asset.data), assetInfo.md5);
         }


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

Resolves an issue we saw in smoke test, related to https://github.com/LLK/scratch-gui/pull/4181

Add a "clean" flag to assets. Assets that get updated WITHOUT requiring an assetId change are set to CLEAN, assets that require id updates are NOT CLEAN. 

This is used by the GUI to only save assets that are NOT CLEAN.

A circumstance where an asset is marked as clean would be loading from any of the helpers. (`asset.setData(...)` without generateId flag)

A circumstance where an asset is marked as not clean would be when the VM loads a 2.0 costume that needs to be updated in storage after being modified. (`asset.setData(..., true)`)

Another circumstance where an asset is marked as not clean is when it is created by the costume editor (`storage.createAsset(..., true)`)

