### PR TITLE
Only evaluate text-encoding on systems that need it

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -2,8 +2,12 @@
 // browser.
 let _TextDecoder;
 let _TextEncoder;
-const encoding = require('text-encoding');
 if (typeof TextDecoder === 'undefined' || typeof TextEncoder === 'undefined') {
+    // Wait to require text-encoding until we _know_ its needed. This will save
+    // evaluating ~500kb of encoding indices that we do not need to evaluate if
+    // the browser provides TextDecoder and TextEncoder.
+    // eslint-disable-next-line global-require
+    const encoding = require('text-encoding');
     _TextDecoder = encoding.TextDecoder;
     _TextEncoder = encoding.TextEncoder;
 } else {


### PR DESCRIPTION
### Resolves

Load and evaluate the javascript for Scratch faster.

### Proposed Changes

Evaluate `text-encoding` once we know it is needed. Making this actually actually happen will need changes in other scratch packages using `text-encoding`.

### Reason for Changes

This lets us skip evaluating ~500kb of encoding indices. Evaluating less code lets us get to kicking of loading data and assets in less time since the page is loaded.

### Benchmark Data

I'll be holding off on producing a table for this. In part as the change is needed in other packages but also the change will be hard to measure. I'll link to a congregate table including a larger set of changes.

I might update this spot with some less comprehensive numbers.
