### PR TITLE
Fetch assets with a web worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "js-md5": "0.7.3",
     "minilog": "3.1.0",
     "nets": "3.2.0",
-    "text-encoding": "0.7.0"
+    "text-encoding": "0.7.0",
+    "worker-loader": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -152,9 +152,14 @@ class BuiltinHelper extends Helper {
      * Fetch an asset but don't process dependencies.
      * @param {AssetType} assetType - The type of asset to fetch.
      * @param {string} assetId - The ID of the asset to fetch: a project ID, MD5, etc.
-     * @return {Promise.<Asset>} A promise for the contents of the asset.
+     * @return {?Promise.<Asset>} A promise for the contents of the asset.
      */
     load (assetType, assetId) {
+        if (!this.get(assetId)) {
+            // Return null immediately so Storage can quickly move to trying the
+            // next helper.
+            return null;
+        }
         return Promise.resolve(this.get(assetId));
     }
 }

--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -23,6 +23,30 @@ class FetchTool {
             .then(result => result.arrayBuffer())
             .then(body => new Uint8Array(body));
     }
+
+    /**
+     * Is sending supported? false if the environment does not support sending
+     * with fetch.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return typeof fetch !== 'undefined';
+    }
+
+    /**
+     * Send data to a server with fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to send.
+     * @param {*} data - Data to send.
+     * @param {string} method - HTTP method to sending the data as.
+     * @returns {Promise.<string>} Server returned metadata.
+     */
+    send ({url}, data, method) {
+        return fetch(url, {
+            method,
+            body: data
+        })
+            .then(result => result.text());
+    }
 }
 
 module.exports = FetchTool;

--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -1,0 +1,28 @@
+/* eslint-env browser */
+
+/**
+ * Get and send assets with the fetch standard web api.
+ */
+class FetchTool {
+    /**
+     * Is get supported? false if the environment does not support fetch.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return typeof fetch !== 'undefined';
+    }
+
+    /**
+     * Request data from a server with fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Uint8Array>} Resolve to Buffer of data from server.
+     */
+    get ({url}, options = {method: 'GET'}) {
+        return fetch(url, options)
+            .then(result => result.arrayBuffer())
+            .then(body => new Uint8Array(body));
+    }
+}
+
+module.exports = FetchTool;

--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -8,7 +8,7 @@ class FetchTool {
      * Is get supported? false if the environment does not support fetch.
      * @returns {boolean} Is get supported?
      */
-    get getSupported () {
+    get isGetSupported () {
         return typeof fetch !== 'undefined';
     }
 
@@ -29,7 +29,7 @@ class FetchTool {
      * with fetch.
      * @returns {boolean} Is sending supported?
      */
-    get sendSupported () {
+    get isSendSupported () {
         return typeof fetch !== 'undefined';
     }
 

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -158,6 +158,22 @@ class PublicFetchWorkerTool {
     get (reqConfig, options) {
         return this.inner.get(reqConfig, options);
     }
+
+    /**
+     * Is sending supported?
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return false;
+    }
+
+    /**
+     * Send data to a server with a worker that uses fetch.
+     * @throws {Error} A not implemented error.
+     */
+    send () {
+        throw new Error('Not implemented.');
+    }
 }
 
 module.exports = PublicFetchWorkerTool;

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -1,0 +1,163 @@
+/**
+ * Get and send assets with a worker that uses fetch.
+ */
+class PrivateFetchWorkerTool {
+    constructor () {
+        /**
+         * What does the worker support of the APIs we need?
+         * @type {{fetch:boolean}}
+         */
+        this._workerSupport = {
+            fetch: typeof fetch !== 'undefined'
+        };
+
+        /**
+         * A possible error occurred standing up the worker.
+         * @type {!Error}
+         */
+        this._supportError = null;
+
+        /**
+         * The worker that runs fetch and returns data for us.
+         * @type {!Worker}
+         */
+        this.worker = null;
+
+        /**
+         * A map of ids to fetch job objects.
+         * @type {object}
+         */
+        this.jobs = {};
+
+        try {
+            if (this.getSupported) {
+                // eslint-disable-next-line global-require
+                const FetchWorker = require('worker-loader?{"inline":true,"fallback":true}!./FetchWorkerTool.worker');
+
+                this.worker = new FetchWorker();
+
+                this.worker.addEventListener('message', ({data}) => {
+                    if (data.support) {
+                        this._workerSupport = data.support;
+                        return;
+                    }
+                    for (const message of data) {
+                        if (this.jobs[message.id]) {
+                            if (message.error) {
+                                this.jobs[message.id].reject(message.error);
+                            } else {
+                                this.jobs[message.id].resolve(message.buffer);
+                            }
+                            delete this.jobs[message.id];
+                        }
+                    }
+                });
+            }
+        } catch (error) {
+            this._supportError = error;
+        }
+    }
+
+    /**
+     * Is get supported?
+     *
+     * false if the environment does not workers, fetch, or fetch from inside a
+     * worker. Finding out the worker supports fetch is asynchronous and will
+     * guess that it does if the window does until the worker can inform us.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return (
+            typeof Worker !== 'undefined' &&
+            this._workerSupport.fetch &&
+            !this._supportError
+        );
+    }
+
+    /**
+     * Request data from a server with a worker using fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get ({url}, options = {method: 'GET'}) {
+        return new Promise((resolve, reject) => {
+            // TODO: Use a Scratch standard ID generator ...
+            const id = Math.random().toString(16)
+                .substring(2);
+            this.worker.postMessage({
+                id,
+                url,
+                options
+            });
+            this.jobs[id] = {
+                id,
+                resolve,
+                reject
+            };
+        })
+            .then(body => new Uint8Array(body));
+    }
+
+    /**
+     * Is sending supported? always false for FetchWorkerTool.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return false;
+    }
+
+    /**
+     * Send data to a server with nets.
+     * @throws {Error} A not implemented error.
+     */
+    send () {
+        throw new Error('Not implemented.');
+    }
+
+    /**
+     * Return a static PrivateFetchWorkerTool instance on demand.
+     * @returns {PrivateFetchWorkerTool} A static PrivateFetchWorkerTool
+     *   instance
+     */
+    static get instance () {
+        if (!this._instance) {
+            this._instance = new PrivateFetchWorkerTool();
+        }
+        return this._instance;
+    }
+}
+
+/**
+ * Get and send assets with a worker that uses fetch.
+ */
+class PublicFetchWorkerTool {
+    constructor () {
+        /**
+         * Shared instance of an internal worker. PublicFetchWorkerTool proxies
+         * it.
+         * @type {PrivateFetchWorkerTool}
+         */
+        this.inner = PrivateFetchWorkerTool.instance;
+    }
+
+    /**
+     * Is get supported?
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return this.inner.getSupported;
+    }
+
+    /**
+     * Request data from a server with a worker that uses fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get (reqConfig, options) {
+        return this.inner.get(reqConfig, options);
+    }
+}
+
+module.exports = PublicFetchWorkerTool;

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -30,7 +30,7 @@ class PrivateFetchWorkerTool {
         this.jobs = {};
 
         try {
-            if (this.getSupported) {
+            if (this.isGetSupported) {
                 // eslint-disable-next-line global-require
                 const FetchWorker = require('worker-loader?{"inline":true,"fallback":true}!./FetchWorkerTool.worker');
 
@@ -66,7 +66,7 @@ class PrivateFetchWorkerTool {
      * guess that it does if the window does until the worker can inform us.
      * @returns {boolean} Is get supported?
      */
-    get getSupported () {
+    get isGetSupported () {
         return (
             typeof Worker !== 'undefined' &&
             this._workerSupport.fetch &&
@@ -103,7 +103,7 @@ class PrivateFetchWorkerTool {
      * Is sending supported? always false for FetchWorkerTool.
      * @returns {boolean} Is sending supported?
      */
-    get sendSupported () {
+    get isSendSupported () {
         return false;
     }
 
@@ -145,8 +145,8 @@ class PublicFetchWorkerTool {
      * Is get supported?
      * @returns {boolean} Is get supported?
      */
-    get getSupported () {
-        return this.inner.getSupported;
+    get isGetSupported () {
+        return this.inner.isGetSupported;
     }
 
     /**
@@ -163,7 +163,7 @@ class PublicFetchWorkerTool {
      * Is sending supported?
      * @returns {boolean} Is sending supported?
      */
-    get sendSupported () {
+    get isSendSupported () {
         return false;
     }
 

--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -1,0 +1,54 @@
+/* eslint-env worker */
+
+let jobsActive = 0;
+const complete = [];
+
+let intervalId = null;
+
+/**
+ * Register a step function.
+ *
+ * Step checks if there are completed jobs and if there are sends them to the
+ * parent. Then it checks the jobs count. If there are no further jobs, clear
+ * the step.
+ */
+const registerStep = function () {
+    intervalId = setInterval(() => {
+        if (complete.length) {
+            postMessage(complete.slice(), complete.map(response => response.buffer).filter(Boolean));
+            complete.length = 0;
+        }
+        if (jobsActive === 0) {
+            clearInterval(intervalId);
+            intervalId = null;
+        }
+    }, 1);
+};
+
+/**
+ * Receive a job from the parent and fetch the requested data.
+ * @param {object} options.job A job id, url, and options descriptor to perform.
+ */
+const onMessage = ({data: job}) => {
+    if (jobsActive === 0 && !intervalId) {
+        registerStep();
+    }
+
+    jobsActive++;
+
+    fetch(job.url, job.options)
+        .then(response => response.arrayBuffer())
+        .then(buffer => complete.push({id: job.id, buffer}))
+        .catch(error => complete.push({id: job.id, error}))
+        .then(() => jobsActive--);
+};
+
+if (self.fetch) {
+    postMessage({support: {fetch: true}});
+    self.addEventListener('message', onMessage);
+} else {
+    postMessage({support: {fetch: false}});
+    self.addEventListener('message', ({data: job}) => {
+        postMessage([{id: job.id, error: new Error('fetch is unavailable')}]);
+    });
+}

--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -15,7 +15,19 @@ let intervalId = null;
 const registerStep = function () {
     intervalId = setInterval(() => {
         if (complete.length) {
-            postMessage(complete.slice(), complete.map(response => response.buffer).filter(Boolean));
+            // Send our chunk of completed requests and instruct postMessage to
+            // transfer the buffers instead of copying them.
+            postMessage(
+                complete.slice(),
+                // Instruct postMessage that these buffers in the sent message
+                // should use their Transferable trait. After the postMessage
+                // call the "buffers" will still be in complete if you looked,
+                // but they will all be length 0 as the data they reference has
+                // been sent to the window. This lets us send a lot of data
+                // without the normal postMessage behaviour of making a copy of
+                // all of the data for the window.
+                complete.map(response => response.buffer).filter(Boolean)
+            );
             complete.length = 0;
         }
         if (jobsActive === 0) {

--- a/src/NetsTool.js
+++ b/src/NetsTool.js
@@ -1,0 +1,39 @@
+/**
+ * Get and send assets with the npm nets package.
+ */
+class NetsTool {
+    /**
+     * Is get supported? false if the environment does not support nets.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return true;
+    }
+
+    /**
+     * Request data from a server with nets.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get (reqConfig) {
+        return new Promise((resolve, reject) => {
+            /* eslint global-require:0 */
+            // Wait to evaluate nets and its dependencies until we know we need
+            // it as NetsTool may never be used if fetch is available.
+            const nets = require('nets');
+
+            nets(Object.assign({
+                method: 'get'
+            }, reqConfig), (err, resp, body) => {
+                // body is a Buffer
+                if (err || Math.floor(resp.statusCode / 100) !== 2) {
+                    reject(err || resp.statusCode);
+                } else {
+                    resolve(body);
+                }
+            });
+        });
+    }
+}
+
+module.exports = NetsTool;

--- a/src/NetsTool.js
+++ b/src/NetsTool.js
@@ -34,6 +34,43 @@ class NetsTool {
             });
         });
     }
+
+    /**
+     * Is sending supported? false if the environment does not support sending
+     * with nets.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return true;
+    }
+
+    /**
+     * Send data to a server with nets.
+     * @param {{url:string}} reqConfig - Request configuration for data to send.
+     * @param {*} data - Data to send.
+     * @param {string} method - HTTP method to sending the data as.
+     * @returns {Promise.<Buffer|string|object>} Server returned metadata.
+     */
+    send (reqConfig, data, method) {
+        return new Promise((resolve, reject) => {
+            /* eslint global-require:0 */
+            // Wait to evaluate nets and its dependencies until we know we need
+            // it as NetsTool may never be used if fetch is available.
+            const nets = require('nets');
+
+            nets(Object.assign({
+                body: data,
+                method: method,
+                encoding: undefined // eslint-disable-line no-undefined
+            }, reqConfig), (err, resp, body) => {
+                if (err || Math.floor(resp.statusCode / 100) !== 2) {
+                    reject(err || resp.statusCode);
+                } else {
+                    resolve(body);
+                }
+            });
+        });
+    }
 }
 
 module.exports = NetsTool;

--- a/src/NetsTool.js
+++ b/src/NetsTool.js
@@ -6,7 +6,7 @@ class NetsTool {
      * Is get supported? false if the environment does not support nets.
      * @returns {boolean} Is get supported?
      */
-    get getSupported () {
+    get isGetSupported () {
         return true;
     }
 
@@ -40,7 +40,7 @@ class NetsTool {
      * with nets.
      * @returns {boolean} Is sending supported?
      */
-    get sendSupported () {
+    get isSendSupported () {
         return true;
     }
 
@@ -53,7 +53,7 @@ class NetsTool {
      */
     send (reqConfig, data, method) {
         return new Promise((resolve, reject) => {
-            /* eslint global-require:0 */
+            // eslint-disable-next-lint global-require
             // Wait to evaluate nets and its dependencies until we know we need
             // it as NetsTool may never be used if fetch is available.
             const nets = require('nets');

--- a/src/ProxyTool.js
+++ b/src/ProxyTool.js
@@ -25,8 +25,8 @@ class ProxyTool {
      * Is get supported? false if all proxied tool return false.
      * @returns {boolean} Is get supported?
      */
-    get getSupported () {
-        return this.tools.some(tool => tool.getSupported);
+    get isGetSupported () {
+        return this.tools.some(tool => tool.isGetSupported);
     }
 
     /**
@@ -39,11 +39,11 @@ class ProxyTool {
         let toolIndex = 0;
         const nextTool = err => {
             const tool = this.tools[toolIndex++];
-            if (!tool.getSupported) {
-                return nextTool(err);
-            }
             if (!tool) {
                 throw err;
+            }
+            if (!tool.isGetSupported) {
+                return nextTool(err);
             }
             return tool.get(reqConfig, options).catch(nextTool);
         };
@@ -54,8 +54,8 @@ class ProxyTool {
      * Is sending supported? false if all proxied tool return false.
      * @returns {boolean} Is sending supported?
      */
-    get sendSupported () {
-        return this.tools.some(tool => tool.sendSupported);
+    get isSendSupported () {
+        return this.tools.some(tool => tool.isSendSupported);
     }
 
     /**
@@ -69,11 +69,11 @@ class ProxyTool {
         let toolIndex = 0;
         const nextTool = err => {
             const tool = this.tools[toolIndex++];
-            if (!tool.sendSupported) {
-                return nextTool(err);
-            }
             if (!tool) {
                 throw err;
+            }
+            if (!tool.isSendSupported) {
+                return nextTool(err);
             }
             return tool.send(reqConfig, data, method).catch(nextTool);
         };

--- a/src/ProxyTool.js
+++ b/src/ProxyTool.js
@@ -1,0 +1,70 @@
+const FetchWorkerTool = require('./FetchWorkerTool');
+const FetchTool = require('./FetchTool');
+const NetsTool = require('./NetsTool');
+
+/**
+ * Get and send assets with other tools in sequence.
+ */
+class ProxyTool {
+    constructor (filter = ProxyTool.TOOL_FILTER.ALL) {
+        let tools;
+        if (filter === ProxyTool.TOOL_FILTER.READY) {
+            tools = [new FetchTool(), new NetsTool()];
+        } else {
+            tools = [new FetchWorkerTool(), new FetchTool(), new NetsTool()];
+        }
+
+        /**
+         * Sequence of tools to proxy.
+         * @type {Array.<Tool>}
+         */
+        this.tools = tools;
+    }
+
+    /**
+     * Is get supported? false if all proxied tool return false.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return this.tools.some(tool => tool.getSupported);
+    }
+
+    /**
+     * Request data from with one of the proxied tools.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get (reqConfig, options) {
+        let toolIndex = 0;
+        const nextTool = err => {
+            const tool = this.tools[toolIndex++];
+            if (!tool.getSupported) {
+                return nextTool(err);
+            }
+            if (!tool) {
+                throw err;
+            }
+            return tool.get(reqConfig, options).catch(nextTool);
+        };
+        return nextTool();
+    }
+}
+
+/**
+ * Constant values that filter the set of tools in a ProxyTool instance.
+ * @enum {string}
+ */
+ProxyTool.TOOL_FILTER = {
+    /**
+     * Use all tools.
+     */
+    ALL: 'all',
+
+    /**
+     * Use tools that are ready right now.
+     */
+    READY: 'ready'
+};
+
+module.exports = ProxyTool;

--- a/src/ProxyTool.js
+++ b/src/ProxyTool.js
@@ -49,6 +49,36 @@ class ProxyTool {
         };
         return nextTool();
     }
+
+    /**
+     * Is sending supported? false if all proxied tool return false.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return this.tools.some(tool => tool.sendSupported);
+    }
+
+    /**
+     * Send data to a server with one of the proxied tools.
+     * @param {{url:string}} reqConfig - Request configuration for data to send.
+     * @param {*} data - Data to send.
+     * @param {string} method - HTTP method to sending the data as.
+     * @returns {Promise.<Buffer|string|object>} Server returned metadata.
+     */
+    send (reqConfig, data, method) {
+        let toolIndex = 0;
+        const nextTool = err => {
+            const tool = this.tools[toolIndex++];
+            if (!tool.sendSupported) {
+                return nextTool(err);
+            }
+            if (!tool) {
+                throw err;
+            }
+            return tool.send(reqConfig, data, method).catch(nextTool);
+        };
+        return nextTool();
+    }
 }
 
 /**

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -4,6 +4,16 @@ const log = require('./log');
 
 const Asset = require('./Asset');
 const Helper = require('./Helper');
+const ProxyTool = require('./ProxyTool');
+
+const ensureRequestConfig = reqConfig => {
+    if (typeof reqConfig === 'string') {
+        return {
+            url: reqConfig
+        };
+    }
+    return reqConfig;
+};
 
 /**
  * @typedef {function} UrlFunction - A function which computes a URL from asset information.
@@ -25,6 +35,21 @@ class WebHelper extends Helper {
          * @property {UrlFunction} updateFunction - A function which computes a URL from an Asset.
          */
         this.stores = [];
+
+        /**
+         * Set of tools to best load many assets in parallel. If one tool
+         * cannot be used, it will use the next.
+         * @type {ProxyTool}
+         */
+        this.assetTool = new ProxyTool();
+
+        /**
+         * Set of tools to best load project data in parallel with assets. This
+         * tool set prefers tools that are immediately ready. Some tools have
+         * to initialize before they can load files.
+         * @type {ProxyTool}
+         */
+        this.projectTool = new ProxyTool(ProxyTool.TOOL_FILTER.READY);
     }
 
     /**
@@ -65,58 +90,40 @@ class WebHelper extends Helper {
 
         /** @type {Array.<{url:string, result:*}>} List of URLs attempted & errors encountered. */
         const errors = [];
-        const stores = this.stores.slice();
+        const stores = this.stores.slice()
+            .filter(store => store.types.indexOf(assetType.name) >= 0);
         const asset = new Asset(assetType, assetId, dataFormat);
+
+        let tool = this.assetTool;
+        if (assetType.name === 'Project') {
+            tool = this.projectTool;
+        }
+
         let storeIndex = 0;
+        const tryNextSource = () => {
+            const store = stores[storeIndex++];
 
-        return new Promise((resolve, reject) => {
+            /** @type {UrlFunction} */
+            const reqConfigFunction = store.get;
 
-            const tryNextSource = () => {
-
-                /** @type {UrlFunction} */
-                let reqConfigFunction;
-
-                while (storeIndex < stores.length) {
-                    const store = stores[storeIndex];
-                    ++storeIndex;
-                    if (store.types.indexOf(assetType.name) >= 0) {
-                        reqConfigFunction = store.get;
-                        break;
-                    }
+            if (reqConfigFunction) {
+                const reqConfig = ensureRequestConfig(reqConfigFunction(asset));
+                if (reqConfig === false) {
+                    return tryNextSource();
                 }
 
-                if (reqConfigFunction) {
-                    let reqConfig = reqConfigFunction(asset);
-                    if (reqConfig === false) {
-                        tryNextSource();
-                        return;
-                    }
-                    if (typeof reqConfig === 'string') {
-                        reqConfig = {
-                            url: reqConfig
-                        };
-                    }
+                return tool.get(reqConfig)
+                    .then(body => asset.setData(body, dataFormat))
+                    .catch(tryNextSource);
+            } else if (errors.length > 0) {
+                return Promise.reject(errors);
+            }
 
-                    nets(Object.assign({
-                        method: 'get'
-                    }, reqConfig), (err, resp, body) => {
-                        // body is a Buffer
-                        if (err || Math.floor(resp.statusCode / 100) !== 2) {
-                            tryNextSource();
-                        } else {
-                            asset.setData(body, dataFormat);
-                            resolve(asset);
-                        }
-                    });
-                } else if (errors.length > 0) {
-                    reject(errors);
-                } else {
-                    resolve(null); // no stores matching asset
-                }
-            };
+            // no stores matching asset
+            return Promise.resolve(null);
+        };
 
-            tryNextSource();
-        });
+        return tryNextSource().then(() => asset);
     }
 
     /**

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -1,5 +1,3 @@
-const nets = require('nets');
-
 const log = require('./log');
 
 const Asset = require('./Asset');
@@ -151,39 +149,34 @@ class WebHelper extends Helper {
 
         const method = create ? 'post' : 'put';
 
-        return new Promise((resolve, reject) => {
-            if (!store) return reject('No appropriate stores');
+        if (!store) return Promise.reject('No appropriate stores');
 
-            let reqConfig = create ? store.create(asset) : store.update(asset);
-            if (typeof reqConfig === 'string') {
-                reqConfig = {
-                    url: reqConfig
-                };
-            }
-            return nets(Object.assign({
-                body: data,
-                method: method,
-                encoding: undefined // eslint-disable-line no-undefined
-            }, reqConfig), (err, resp, body) => {
-                if (err || Math.floor(resp.statusCode / 100) !== 2) {
-                    return reject(err || resp.statusCode);
-                }
-                // xhr makes it difficult to both send FormData and automatically
-                // parse a JSON response. So try to parse everything as JSON.
+        let tool = this.assetTool;
+        if (assetType.name === 'Project') {
+            tool = this.projectTool;
+        }
+
+        const reqConfig = ensureRequestConfig(
+            create ? store.create(asset) : store.update(asset)
+        );
+        return tool.send(reqConfig, data, method)
+            .then(body => {
+                // xhr makes it difficult to both send FormData and
+                // automatically parse a JSON response. So try to parse
+                // everything as JSON.
                 if (typeof body === 'string') {
                     try {
                         body = JSON.parse(body);
                     } catch (parseError) {
                         // If it's not parseable, then we can't add the id even
                         // if we want to, so stop here
-                        return resolve(body);
+                        return body;
                     }
                 }
-                return resolve(Object.assign({
+                return Object.assign({
                     id: body['content-name'] || assetId
-                }, body));
+                }, body);
             });
-        });
     }
 }
 


### PR DESCRIPTION
### Resolves

Load assets faster.

### Proposed Changes

When it makes sense and is possible load assets in a web worker. As well use fetch instead of nets xhr wrapper when possible. If we can't fetch in a worker or fetch in the main thread, fallback to the nets wrapper.

### Reason for Changes

Loading assets in a web worker shifts asset loading overhead, switching between native and js. It also reduces the chance of the js blocking work happening on one of those assets loading. These behaviour changes greatly reduce the time between operating on loading the raw data of assets.

### Benchmark Data

Can be compared against the baseline in https://github.com/LLK/scratch-vm/pull/1944.

project id | platform | run 1 | run 2 | run 3 | run 4 | run 5 | avg
--------- | ------ | ---- | ---- | ---- | ---- | ---- | ----
169401431 | chrome | 7124 | 6821 | 7042 | 6598 | 6794 | 6875.8
169401431 | firefox | 5946 | 4139 | 3739 | 4098 | 4456 | 4475.6
169401431 | safari | 10614 | 7203 | 7190 | 7281 | 6974 | 7852.4
169401431 | book | 18692 | 16970 | 17106 | 17232 | 16304 | 17260.8
173918262 | chrome | 1860 | 1472 | 1325 | 1283 | 1178 | 1423.6
173918262 | firefox | 1312 | 1188 | 1184 | 1255 | 1155 | 1218.8
173918262 | safari | 2207 | 1030 | 1155 | 1061 | 1079 | 1306.4
173918262 | book | 5642 | 3054 | 2489 | 2527 | 2921 | 3326.6
173918262 | pi | 26373 | 17820 | 16502 | 18263 | 16711 | 19133.8
