### PR TITLE
Immediately use next tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "js-md5": "0.7.3",
     "minilog": "3.1.0",
     "nets": "3.2.0",
-    "text-encoding": "0.7.0"
+    "text-encoding": "0.7.0",
+    "worker-loader": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -152,9 +152,14 @@ class BuiltinHelper extends Helper {
      * Fetch an asset but don't process dependencies.
      * @param {AssetType} assetType - The type of asset to fetch.
      * @param {string} assetId - The ID of the asset to fetch: a project ID, MD5, etc.
-     * @return {Promise.<Asset>} A promise for the contents of the asset.
+     * @return {?Promise.<Asset>} A promise for the contents of the asset.
      */
     load (assetType, assetId) {
+        if (!this.get(assetId)) {
+            // Return null immediately so Storage can quickly move to trying the
+            // next helper.
+            return null;
+        }
         return Promise.resolve(this.get(assetId));
     }
 }

--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -23,6 +23,30 @@ class FetchTool {
             .then(result => result.arrayBuffer())
             .then(body => new Uint8Array(body));
     }
+
+    /**
+     * Is sending supported? false if the environment does not support sending
+     * with fetch.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return typeof fetch !== 'undefined';
+    }
+
+    /**
+     * Send data to a server with fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to send.
+     * @param {*} data - Data to send.
+     * @param {string} method - HTTP method to sending the data as.
+     * @returns {Promise.<string>} Server returned metadata.
+     */
+    send ({url}, data, method) {
+        return fetch(url, {
+            method,
+            body: data
+        })
+            .then(result => result.text());
+    }
 }
 
 module.exports = FetchTool;

--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -1,0 +1,28 @@
+/* eslint-env browser */
+
+/**
+ * Get and send assets with the fetch standard web api.
+ */
+class FetchTool {
+    /**
+     * Is get supported? false if the environment does not support fetch.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return typeof fetch !== 'undefined';
+    }
+
+    /**
+     * Request data from a server with fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Uint8Array>} Resolve to Buffer of data from server.
+     */
+    get ({url}, options = {method: 'GET'}) {
+        return fetch(url, options)
+            .then(result => result.arrayBuffer())
+            .then(body => new Uint8Array(body));
+    }
+}
+
+module.exports = FetchTool;

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -1,0 +1,175 @@
+/**
+ * Get and send assets with a worker that uses fetch.
+ */
+class PrivateFetchWorkerTool {
+    constructor () {
+        /**
+         * What does the worker support of the APIs we need?
+         * @type {{fetch:boolean}}
+         */
+        this._workerSupport = {
+            fetch: typeof fetch !== 'undefined'
+        };
+
+        /**
+         * A possible error occurred standing up the worker.
+         * @type {!Error}
+         */
+        this._supportError = null;
+
+        /**
+         * The worker that runs fetch and returns data for us.
+         * @type {!Worker}
+         */
+        this.worker = null;
+
+        /**
+         * A map of ids to fetch job objects.
+         * @type {object}
+         */
+        this.jobs = {};
+
+        try {
+            if (this.getSupported) {
+                // eslint-disable-next-line global-require
+                const FetchWorker = require('worker-loader?{"inline":true,"fallback":true}!./FetchWorkerTool.worker');
+
+                this.worker = new FetchWorker();
+
+                this.worker.addEventListener('message', ({data}) => {
+                    if (data.support) {
+                        this._workerSupport = data.support;
+                        return;
+                    }
+                    for (const message of data) {
+                        if (this.jobs[message.id]) {
+                            if (message.error) {
+                                this.jobs[message.id].reject(message.error);
+                            } else {
+                                this.jobs[message.id].resolve(message.buffer);
+                            }
+                            delete this.jobs[message.id];
+                        }
+                    }
+                });
+            }
+        } catch (error) {
+            this._supportError = error;
+        }
+    }
+
+    /**
+     * Is get supported?
+     *
+     * false if the environment does not workers, fetch, or fetch from inside a
+     * worker. Finding out the worker supports fetch is asynchronous and will
+     * guess that it does if the window does until the worker can inform us.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return (
+            typeof Worker !== 'undefined' &&
+            this._workerSupport.fetch &&
+            !this._supportError
+        );
+    }
+
+    /**
+     * Request data from a server with a worker using fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get ({url}, options = {method: 'GET'}) {
+        // TODO: This is rather knowledgeable of what data urls look like. Can
+        // it be abstracted or less knowledgable while letting FetchTool do the
+        // job with data?
+        if (/\/\w+\/get\/$|\.json/.test(url)) {
+            // Load extension-less files with another tool. The worker needs
+            // time to load and start up. Loading json or other data through a
+            // main process tool (fetch or nets) will return a faster result
+            // than waiting for the worker to start and send its fetch
+            // operation.
+            return Promise.reject(new Error('FetchWorkerTool does not load extension-less items.'));
+        }
+
+        return new Promise((resolve, reject) => {
+            // TODO: Use a Scratch standard ID generator ...
+            const id = Math.random().toString(16)
+                .substring(2);
+            this.worker.postMessage({
+                id,
+                url,
+                options
+            });
+            this.jobs[id] = {
+                id,
+                resolve,
+                reject
+            };
+        })
+            .then(body => new Uint8Array(body));
+    }
+
+    /**
+     * Is sending supported? always false for FetchWorkerTool.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return false;
+    }
+
+    /**
+     * Send data to a server with nets.
+     * @throws {Error} A not implemented error.
+     */
+    send () {
+        throw new Error('Not implemented.');
+    }
+
+    /**
+     * Return a static PrivateFetchWorkerTool instance on demand.
+     * @returns {PrivateFetchWorkerTool} A static PrivateFetchWorkerTool
+     *   instance
+     */
+    static get instance () {
+        if (!this._instance) {
+            this._instance = new PrivateFetchWorkerTool();
+        }
+        return this._instance;
+    }
+}
+
+/**
+ * Get and send assets with a worker that uses fetch.
+ */
+class PublicFetchWorkerTool {
+    constructor () {
+        /**
+         * Shared instance of an internal worker. PublicFetchWorkerTool proxies
+         * it.
+         * @type {PrivateFetchWorkerTool}
+         */
+        this.inner = PrivateFetchWorkerTool.instance;
+    }
+
+    /**
+     * Is get supported?
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return this.inner.getSupported;
+    }
+
+    /**
+     * Request data from a server with a worker that uses fetch.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get (reqConfig, options) {
+        return this.inner.get(reqConfig, options);
+    }
+}
+
+module.exports = PublicFetchWorkerTool;

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -170,6 +170,22 @@ class PublicFetchWorkerTool {
     get (reqConfig, options) {
         return this.inner.get(reqConfig, options);
     }
+
+    /**
+     * Is sending supported?
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return false;
+    }
+
+    /**
+     * Send data to a server with a worker that uses fetch.
+     * @throws {Error} A not implemented error.
+     */
+    send () {
+        throw new Error('Not implemented.');
+    }
 }
 
 module.exports = PublicFetchWorkerTool;

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -90,7 +90,10 @@ class PrivateFetchWorkerTool {
             // main process tool (fetch or nets) will return a faster result
             // than waiting for the worker to start and send its fetch
             // operation.
-            return Promise.reject(new Error('FetchWorkerTool does not load extension-less items.'));
+            //
+            // Return null to indicate to ProxyTool that FetchWorkerTool will
+            // not get this requested url.
+            return null;
         }
 
         return new Promise((resolve, reject) => {

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -29,6 +29,15 @@ class PrivateFetchWorkerTool {
          */
         this.jobs = {};
 
+        Promise.resolve()
+            .then(() => {
+                if (this.worker === null && this._supportError === null) {
+                    this.initWorker();
+                }
+            });
+    }
+
+    initWorker () {
         try {
             if (this.getSupported) {
                 // eslint-disable-next-line global-require
@@ -94,6 +103,10 @@ class PrivateFetchWorkerTool {
             // Return null to indicate to ProxyTool that FetchWorkerTool will
             // not get this requested url.
             return null;
+        }
+
+        if (this.worker === null && this._supportError === null) {
+            this.initWorker();
         }
 
         return new Promise((resolve, reject) => {

--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -1,0 +1,54 @@
+/* eslint-env worker */
+
+let jobsActive = 0;
+const complete = [];
+
+let intervalId = null;
+
+/**
+ * Register a step function.
+ *
+ * Step checks if there are completed jobs and if there are sends them to the
+ * parent. Then it checks the jobs count. If there are no further jobs, clear
+ * the step.
+ */
+const registerStep = function () {
+    intervalId = setInterval(() => {
+        if (complete.length) {
+            postMessage(complete.slice(), complete.map(response => response.buffer).filter(Boolean));
+            complete.length = 0;
+        }
+        if (jobsActive === 0) {
+            clearInterval(intervalId);
+            intervalId = null;
+        }
+    }, 1);
+};
+
+/**
+ * Receive a job from the parent and fetch the requested data.
+ * @param {object} options.job A job id, url, and options descriptor to perform.
+ */
+const onMessage = ({data: job}) => {
+    if (jobsActive === 0 && !intervalId) {
+        registerStep();
+    }
+
+    jobsActive++;
+
+    fetch(job.url, job.options)
+        .then(response => response.arrayBuffer())
+        .then(buffer => complete.push({id: job.id, buffer}))
+        .catch(error => complete.push({id: job.id, error}))
+        .then(() => jobsActive--);
+};
+
+if (self.fetch) {
+    postMessage({support: {fetch: true}});
+    self.addEventListener('message', onMessage);
+} else {
+    postMessage({support: {fetch: false}});
+    self.addEventListener('message', ({data: job}) => {
+        postMessage([{id: job.id, error: new Error('fetch is unavailable')}]);
+    });
+}

--- a/src/NetsTool.js
+++ b/src/NetsTool.js
@@ -1,0 +1,39 @@
+/**
+ * Get and send assets with the npm nets package.
+ */
+class NetsTool {
+    /**
+     * Is get supported? false if the environment does not support nets.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return true;
+    }
+
+    /**
+     * Request data from a server with nets.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get (reqConfig) {
+        return new Promise((resolve, reject) => {
+            /* eslint global-require:0 */
+            // Wait to evaluate nets and its dependencies until we know we need
+            // it as NetsTool may never be used if fetch is available.
+            const nets = require('nets');
+
+            nets(Object.assign({
+                method: 'get'
+            }, reqConfig), (err, resp, body) => {
+                // body is a Buffer
+                if (err || Math.floor(resp.statusCode / 100) !== 2) {
+                    reject(err || resp.statusCode);
+                } else {
+                    resolve(body);
+                }
+            });
+        });
+    }
+}
+
+module.exports = NetsTool;

--- a/src/NetsTool.js
+++ b/src/NetsTool.js
@@ -34,6 +34,43 @@ class NetsTool {
             });
         });
     }
+
+    /**
+     * Is sending supported? false if the environment does not support sending
+     * with nets.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return true;
+    }
+
+    /**
+     * Send data to a server with nets.
+     * @param {{url:string}} reqConfig - Request configuration for data to send.
+     * @param {*} data - Data to send.
+     * @param {string} method - HTTP method to sending the data as.
+     * @returns {Promise.<Buffer|string|object>} Server returned metadata.
+     */
+    send (reqConfig, data, method) {
+        return new Promise((resolve, reject) => {
+            /* eslint global-require:0 */
+            // Wait to evaluate nets and its dependencies until we know we need
+            // it as NetsTool may never be used if fetch is available.
+            const nets = require('nets');
+
+            nets(Object.assign({
+                body: data,
+                method: method,
+                encoding: undefined // eslint-disable-line no-undefined
+            }, reqConfig), (err, resp, body) => {
+                if (err || Math.floor(resp.statusCode / 100) !== 2) {
+                    reject(err || resp.statusCode);
+                } else {
+                    resolve(body);
+                }
+            });
+        });
+    }
 }
 
 module.exports = NetsTool;

--- a/src/ProxyTool.js
+++ b/src/ProxyTool.js
@@ -1,0 +1,43 @@
+const FetchWorkerTool = require('./FetchWorkerTool');
+const FetchTool = require('./FetchTool');
+const NetsTool = require('./NetsTool');
+
+/**
+ * Get and send assets with other tools in sequence.
+ */
+class ProxyTool {
+    constructor () {
+        this.tools = [new FetchWorkerTool(), new FetchTool(), new NetsTool()];
+    }
+
+    /**
+     * Is get supported? false if all proxied tool return false.
+     * @returns {boolean} Is get supported?
+     */
+    get getSupported () {
+        return this.tools.some(tool => tool.getSupported);
+    }
+
+    /**
+     * Request data from with one of the proxied tools.
+     * @param {{url:string}} reqConfig - Request configuration for data to get.
+     * @param {{method:string}} options - Additional options to configure fetch.
+     * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
+     */
+    get (reqConfig, options) {
+        let toolIndex = 0;
+        const nextTool = err => {
+            const tool = this.tools[toolIndex++];
+            if (!tool.getSupported) {
+                return nextTool(err);
+            }
+            if (!tool) {
+                throw err;
+            }
+            return tool.get(reqConfig, options).catch(nextTool);
+        };
+        return nextTool();
+    }
+}
+
+module.exports = ProxyTool;

--- a/src/ProxyTool.js
+++ b/src/ProxyTool.js
@@ -38,6 +38,36 @@ class ProxyTool {
         };
         return nextTool();
     }
+
+    /**
+     * Is sending supported? false if all proxied tool return false.
+     * @returns {boolean} Is sending supported?
+     */
+    get sendSupported () {
+        return this.tools.some(tool => tool.sendSupported);
+    }
+
+    /**
+     * Send data to a server with one of the proxied tools.
+     * @param {{url:string}} reqConfig - Request configuration for data to send.
+     * @param {*} data - Data to send.
+     * @param {string} method - HTTP method to sending the data as.
+     * @returns {Promise.<Buffer|string|object>} Server returned metadata.
+     */
+    send (reqConfig, data, method) {
+        let toolIndex = 0;
+        const nextTool = err => {
+            const tool = this.tools[toolIndex++];
+            if (!tool.sendSupported) {
+                return nextTool(err);
+            }
+            if (!tool) {
+                throw err;
+            }
+            return tool.send(reqConfig, data, method).catch(nextTool);
+        };
+        return nextTool();
+    }
 }
 
 module.exports = ProxyTool;

--- a/src/ProxyTool.js
+++ b/src/ProxyTool.js
@@ -7,7 +7,11 @@ const NetsTool = require('./NetsTool');
  */
 class ProxyTool {
     constructor () {
-        this.tools = [new FetchWorkerTool(), new FetchTool(), new NetsTool()];
+        this.tools = [
+            new FetchWorkerTool(),
+            new FetchTool(),
+            new NetsTool()
+        ];
     }
 
     /**
@@ -34,7 +38,15 @@ class ProxyTool {
             if (!tool) {
                 throw err;
             }
-            return tool.get(reqConfig, options).catch(nextTool);
+            try {
+                const getPromise = tool.get(reqConfig, options);
+                if (getPromise === null) {
+                    return nextTool();
+                }
+                return getPromise.catch(nextTool);
+            } catch (_err) {
+                return nextTool(_err);
+            }
         };
         return nextTool();
     }


### PR DESCRIPTION
### Resolves

Load data as soon as possible.

### Proposed Changes

Depends on #78 

- return null in FetchWorkerTool for data files
- initialize FetchWorkerTool.worker late

### Reason for Changes

- return null in FetchWorkerTool for data files
  This lets ScratchStorage, WebHelper, and ProxyTool iterate through its options until it hits FetchTool to load data files. This will let the fetch execute as soon as `storage.load` is called instead of delaying the fetch call.
- initialize FetchWorkerTool.worker late
  This can let fetching data happen even earlier by delaying evaluating the worker-loader, creating the Blob (for systems that support it), and create the worker.

### Benchmark Data

This provides a small but important improvement.

Pending ...
