### PR TITLE
fix: encode buffers with btoa through a binary string

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -12,14 +12,63 @@ if (typeof TextDecoder === 'undefined' || typeof TextEncoder === 'undefined') {
     _TextEncoder = TextEncoder;
 }
 
-const base64js = require('base64-js');
 const md5 = require('js-md5');
 
 const memoizedToString = (function () {
+    /**
+     * The maximum length of a chunk before encoding it into base64.
+     *
+     * 32766 is a multiple of 3 so btoa does not need to use padding characters
+     * except for the final chunk where that is fine. 32766 is also close to
+     * 32768 so it is close to a size an memory allocator would prefer.
+     * @const {number}
+     */
+    const BTOA_CHUNK_MAX_LENGTH = 32766;
+
+    /**
+     * An array cache of bytes to characters.
+     * @const {?Array.<string>}
+     */
+    let fromCharCode = null;
+
     const strings = {};
     return (assetId, data) => {
         if (!strings.hasOwnProperty(assetId)) {
-            strings[assetId] = base64js.fromByteArray(data);
+            if (typeof btoa === 'undefined') {
+                // Use a library that does not need btoa to run.
+                /* eslint-disable-next-line global-require */
+                const base64js = require('base64-js');
+                strings[assetId] = base64js.fromByteArray(data);
+            } else {
+                // Native btoa is faster than javascript translation. Use js to
+                // create a "binary" string and btoa to encode it.
+                if (fromCharCode === null) {
+                    // Cache the first 256 characters for input byte values.
+                    fromCharCode = new Array(256);
+                    for (let i = 0; i < 256; i++) {
+                        fromCharCode[i] = String.fromCharCode(i);
+                    }
+                }
+
+                const {length} = data;
+                let s = '';
+                // Iterate over chunks of the binary data.
+                for (let i = 0, e = 0; i < length; i = e) {
+                    // Create small chunks to cause more small allocations and
+                    // less large allocations.
+                    e = Math.min(e + BTOA_CHUNK_MAX_LENGTH, length);
+                    let s_ = '';
+                    for (let j = i; j < e; j += 1) {
+                        s_ += fromCharCode[data[j]];
+                    }
+                    // Encode the latest chunk so the we create one big output
+                    // string instead of creating a big input string and then
+                    // one big output string.
+                    /* global btoa */
+                    s += btoa(s_);
+                }
+                strings[assetId] = s;
+            }
         }
         return strings[assetId];
     };


### PR DESCRIPTION
### Resolves

Load gui and projects faster.

### Proposed Changes

- Use native btoa to encode buffers into base64 if available.

### Reason for Changes

- Native btoa is faster and uses less memory (allocations are more manually than in js) than base64-js.

### Benchmark Data

Pending ...
