### PR TITLE
perf: remove implicit caching of all loaded assets

### DIFF
--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -193,9 +193,9 @@ class ScratchStorage {
                 if (loading === null) {
                     return tryNextHelper();
                 }
+                // Note that other attempts may have logged errors; if this succeeds they will be suppressed.
                 return loading
-                    // TODO: maybe some types of error should prevent trying the
-                    // next helper?
+                    // TODO: maybe some types of error should prevent trying the next helper?
                     .catch(tryNextHelper);
             } else if (errors.length > 0) {
                 // At least one thing went wrong and also we couldn't find the
@@ -207,22 +207,7 @@ class ScratchStorage {
             return Promise.resolve(null);
         };
 
-        return tryNextHelper()
-            .then(asset => {
-                // TODO? this.localHelper.cache(assetType, assetId, asset);
-                if (helper !== this.builtinHelper && asset && assetType.immutable) {
-                    asset.assetId = this.builtinHelper._store(
-                        assetType,
-                        asset.dataFormat,
-                        asset.data,
-                        assetId
-                    );
-                }
-
-                // Note that other attempts may have caused errors, effectively
-                // suppressed here.
-                return asset;
-            });
+        return tryNextHelper();
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

This change removes the call to `builtinHelper._store()` that was in `ScratchStorage`'s `load()` method, `load()` method, which means we no longer automatically cache every loaded asset in JS memory.

### Reason for Changes

This layer of caching was added at a time when `scratch-storage` "owned" the live assets being used by the rest of Scratch. Updating an asset, for example after committing a costume edit in the paint editor or after modifying a sound, meant caching the new content in the storage module so that other parts of the system could retrieve the modified content.

Since then we have shifted ownership of assets away from `scratch-storage`, eliminating the need to update the contents of an asset in `scratch-storage`. This means caching every asset in the storage module is no longer necessary.

The deprecated `cache()` method may still be used in cases which need to explicitly cache something, and we still call `builtinHelper._store()` from `ScratchStorage`'s `store()` method. Eventually those should go away too, but for now this more conservative change should eliminate at least some unnecessary caching. In particular, this change should significantly reduce the memory used by LLK/scratch-gui#4644.

### Test Coverage

Covered by existing tests.