### PR TITLE
fix: overwrite options to fetch like they are for nets

### DIFF
--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -18,8 +18,8 @@ class FetchTool {
      * @param {{method:string}} options - Additional options to configure fetch.
      * @returns {Promise.<Uint8Array>} Resolve to Buffer of data from server.
      */
-    get ({url}, options = {method: 'GET'}) {
-        return fetch(url, options)
+    get ({url, ...options}) {
+        return fetch(url, Object.assign({method: 'GET'}, options))
             .then(result => result.arrayBuffer())
             .then(body => new Uint8Array(body));
     }
@@ -35,16 +35,13 @@ class FetchTool {
 
     /**
      * Send data to a server with fetch.
-     * @param {{url:string}} reqConfig - Request configuration for data to send.
-     * @param {*} data - Data to send.
-     * @param {string} method - HTTP method to sending the data as.
+     * @param {Request} reqConfig - Request configuration for data to send.
      * @returns {Promise.<string>} Server returned metadata.
      */
-    send ({url}, data, method) {
-        return fetch(url, {
-            method,
-            body: data
-        })
+    send ({url, withCredentials = false, ...options}) {
+        return fetch(url, Object.assign({
+            credentials: withCredentials ? 'include' : 'omit'
+        }, options))
             .then(result => result.text());
     }
 }

--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -80,7 +80,7 @@ class PrivateFetchWorkerTool {
      * @param {{method:string}} options - Additional options to configure fetch.
      * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
      */
-    get ({url}, options = {method: 'GET'}) {
+    get ({url, ...options}) {
         return new Promise((resolve, reject) => {
             // TODO: Use a Scratch standard ID generator ...
             const id = Math.random().toString(16)
@@ -88,7 +88,7 @@ class PrivateFetchWorkerTool {
             this.worker.postMessage({
                 id,
                 url,
-                options
+                options: Object.assign({method: 'GET'}, options)
             });
             this.jobs[id] = {
                 id,
@@ -152,11 +152,10 @@ class PublicFetchWorkerTool {
     /**
      * Request data from a server with a worker that uses fetch.
      * @param {{url:string}} reqConfig - Request configuration for data to get.
-     * @param {{method:string}} options - Additional options to configure fetch.
      * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
      */
-    get (reqConfig, options) {
-        return this.inner.get(reqConfig, options);
+    get (reqConfig) {
+        return this.inner.get(reqConfig);
     }
 
     /**

--- a/src/NetsTool.js
+++ b/src/NetsTool.js
@@ -46,12 +46,10 @@ class NetsTool {
 
     /**
      * Send data to a server with nets.
-     * @param {{url:string}} reqConfig - Request configuration for data to send.
-     * @param {*} data - Data to send.
-     * @param {string} method - HTTP method to sending the data as.
+     * @param {Request} reqConfig - Request configuration for data to send.
      * @returns {Promise.<Buffer|string|object>} Server returned metadata.
      */
-    send (reqConfig, data, method) {
+    send (reqConfig) {
         return new Promise((resolve, reject) => {
             // eslint-disable-next-lint global-require
             // Wait to evaluate nets and its dependencies until we know we need
@@ -59,8 +57,6 @@ class NetsTool {
             const nets = require('nets');
 
             nets(Object.assign({
-                body: data,
-                method: method,
                 encoding: undefined // eslint-disable-line no-undefined
             }, reqConfig), (err, resp, body) => {
                 if (err || Math.floor(resp.statusCode / 100) !== 2) {

--- a/src/ProxyTool.js
+++ b/src/ProxyTool.js
@@ -3,6 +3,14 @@ const FetchTool = require('./FetchTool');
 const NetsTool = require('./NetsTool');
 
 /**
+ * @typedef {object} Request
+ * @property {string} url
+ * @property {*} body
+ * @property {string} method
+ * @property {boolean} withCredentials
+ */
+
+/**
  * Get and send assets with other tools in sequence.
  */
 class ProxyTool {
@@ -31,11 +39,10 @@ class ProxyTool {
 
     /**
      * Request data from with one of the proxied tools.
-     * @param {{url:string}} reqConfig - Request configuration for data to get.
-     * @param {{method:string}} options - Additional options to configure fetch.
+     * @param {Request} reqConfig - Request configuration for data to get.
      * @returns {Promise.<Buffer>} Resolve to Buffer of data from server.
      */
-    get (reqConfig, options) {
+    get (reqConfig) {
         let toolIndex = 0;
         const nextTool = err => {
             const tool = this.tools[toolIndex++];
@@ -45,7 +52,7 @@ class ProxyTool {
             if (!tool.isGetSupported) {
                 return nextTool(err);
             }
-            return tool.get(reqConfig, options).catch(nextTool);
+            return tool.get(reqConfig).catch(nextTool);
         };
         return nextTool();
     }
@@ -60,12 +67,10 @@ class ProxyTool {
 
     /**
      * Send data to a server with one of the proxied tools.
-     * @param {{url:string}} reqConfig - Request configuration for data to send.
-     * @param {*} data - Data to send.
-     * @param {string} method - HTTP method to sending the data as.
+     * @param {Request} reqConfig - Request configuration for data to send.
      * @returns {Promise.<Buffer|string|object>} Server returned metadata.
      */
-    send (reqConfig, data, method) {
+    send (reqConfig) {
         let toolIndex = 0;
         const nextTool = err => {
             const tool = this.tools[toolIndex++];
@@ -75,7 +80,7 @@ class ProxyTool {
             if (!tool.isSendSupported) {
                 return nextTool(err);
             }
-            return tool.send(reqConfig, data, method).catch(nextTool);
+            return tool.send(reqConfig).catch(nextTool);
         };
         return nextTool();
     }

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -159,7 +159,8 @@ class WebHelper extends Helper {
         const reqConfig = ensureRequestConfig(
             create ? store.create(asset) : store.update(asset)
         );
-        return tool.send(reqConfig, data, method)
+        const reqBodyConfig = Object.assign({body: data, method}, reqConfig);
+        return tool.send(reqBodyConfig)
             .then(body => {
                 // xhr makes it difficult to both send FormData and
                 // automatically parse a JSON response. So try to parse


### PR DESCRIPTION
### Resolves

Fix https://github.com/LLK/scratch-storage/issues/88

### Proposed Changes

- Support overwrite default options storage uses for fetch requests like we do with nets
- Change the *Tool get and send APIs to just take a Request object

### Reason for Changes

scratch-gui uses the web store url functions to overwrite the method for assets to always be post. To carry that value to the request we need to pass it in the options to fetch somehow.
