### PR TITLE
Update README: change addWebSource to addWebStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ var getAssetUrl = function (asset) {
 
 Then, let the storage module know about your source:
 ```js
-storage.addWebSource(
+storage.addWebStore(
     [AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound],
     getAssetUrl);
 ```
 
 If you're using ES6 you may be able to simplify all of the above quite a bit:
 ```js
-storage.addWebSource(
+storage.addWebStore(
     [AssetType.ImageVector, AssetType.ImageBitmap, AssetType.Sound],
     asset => `https://assets.example.com/path/to/assets/${asset.assetId}.${asset.dataFormat}/get/`);
 ```


### PR DESCRIPTION
The README file has a reference to `addWebSource` which is [deprecated](https://github.com/LLK/scratch-storage/blob/698d50b444d413d8eafa01c7cf720aba1296f83d/src/ScratchStorage.js#L137)!

This PR changes to addWebStore.