### PR TITLE
fix: return status code from fetch send failures like the nets tool

### DIFF
--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -42,7 +42,10 @@ class FetchTool {
         return fetch(url, Object.assign({
             credentials: withCredentials ? 'include' : 'omit'
         }, options))
-            .then(result => result.text());
+            .then(response => {
+                if (response.ok) return response.text();
+                return Promise.reject(response.status);
+            });
     }
 }
 

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -1,0 +1,29 @@
+const test = require('tap').test;
+
+const FetchTool = require('../../src/FetchTool');
+
+test('send success returns response.text()', t => {
+    global.fetch = () => Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve('successful response')
+    });
+
+    const tool = new FetchTool();
+    
+    return tool.send('url').then(result => {
+        t.equal(result, 'successful response');
+    });
+});
+
+test('send failure returns response.status', t => {
+    global.fetch = () => Promise.resolve({
+        ok: false,
+        status: 500
+    });
+
+    const tool = new FetchTool();
+
+    return tool.send('url').catch(reason => {
+        t.equal(reason, 500);
+    });
+});


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
Fixes https://github.com/LLK/scratch-storage/issues/100

### Proposed Changes

_Describe what this Pull Request does_

Reject calls to `storage.store` that fail through the fetch tools "send" method because of server errors. Use the [`response.ok`](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) property to see if the send was successful, and reject with [`response.status`](https://developer.mozilla.org/en-US/docs/Web/API/Response/status) if it is not ok.  

### Reason for Changes

_Explain why these changes should be made_

This will make it possible for consumers of storage to know when storing an asset fails, and the reason for the failure.

### Test Coverage

_Please show how you have added tests to cover your changes_

Added a unit test for the fetch tool covering the successful and not successful usages

/cc @rschamp 