### PR TITLE
Replace text-encoding package with fastestsmallesttextencoderdecoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "arraybuffer-loader": "^1.0.3",
     "base64-js": "1.3.0",
+    "fastestsmallesttextencoderdecoder": "^1.0.7",
     "js-md5": "0.7.3",
     "minilog": "3.1.0",
-    "text-encoding": "0.7.0",
     "worker-loader": "^2.0.0"
   },
   "devDependencies": {

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -3,11 +3,9 @@
 let _TextDecoder;
 let _TextEncoder;
 if (typeof TextDecoder === 'undefined' || typeof TextEncoder === 'undefined') {
-    // Wait to require text-encoding until we _know_ its needed. This will save
-    // evaluating ~500kb of encoding indices that we do not need to evaluate if
-    // the browser provides TextDecoder and TextEncoder.
+    // Wait to require the text encoding polyfill until we know it's needed.
     // eslint-disable-next-line global-require
-    const encoding = require('text-encoding');
+    const encoding = require('fastestsmallesttextencoderdecoder');
     _TextDecoder = encoding.TextDecoder;
     _TextEncoder = encoding.TextEncoder;
 } else {


### PR DESCRIPTION
### Proposed Changes

This PR replaces the [deprecated and unmaintained `text-encoding` package](https://www.npmjs.com/package/text-encoding), which polyfills the `TextEncoder` and `TextDecoder` APIs, with [`fastestsmallesttextencoderdecoder`](https://www.npmjs.com/package/fastestsmallesttextencoderdecoder).

### Reason for Changes

The main draw of `text-encoding` is that it supports text encodings other than UTF-8. However, we never use this functionality.

This entirely unused support for legacy encodings adds **500kb** of encoding data to the package. Replacing the polyfill with `fastestsmallesttextencoderdecoder`, which only supports UTF-8, removes this 500kb.

The `text-encoding` package is also pulled in by a few other Scratch repositories (scratch-vm, scratch-gui, and scratch-sb1-converter), and they don't use the non-UTF-8 functionality either. I'd remove it in all those repositories too, but I'd rather not "spam" pull requests.

I have not benchmarked load times. That may be worth looking into.

### Test Coverage

I have tested this in Edge, which is the only browser without native support for the Text Encoding API, and it works.