### PR TITLE
Fix the problem that it can respond normally even in fetch 404 status

### DIFF
--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -49,7 +49,12 @@ const onMessage = ({data: job}) => {
     jobsActive++;
 
     fetch(job.url, job.options)
-        .then(response => response.arrayBuffer())
+        .then(response => {
+            if (response.ok) {
+                return response.arrayBuffer();
+            }
+            throw response;
+        })
         .then(buffer => complete.push({id: job.id, buffer}))
         .catch(error => complete.push({id: job.id, error}))
         .then(() => jobsActive--);


### PR DESCRIPTION
### Resolves

If the server of the custom WebStore responds to 404 normally, the asset will not be loaded correctly

### Reason for Changes

When response.ok is false, an exception is thrown to make it try the next web store

