### PR TITLE
fix(builtinhelper): use Buffer.from instead of deprecated constructor

### DIFF
--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -23,7 +23,7 @@ const DefaultAssets = [
         type: AssetType.ImageBitmap,
         format: DataFormat.PNG,
         id: null,
-        data: new Buffer(
+        data: Buffer.from(
             require('!arraybuffer-loader!./builtins/defaultBitmap.png') // eslint-disable-line global-require
         )
     },
@@ -31,7 +31,7 @@ const DefaultAssets = [
         type: AssetType.Sound,
         format: DataFormat.WAV,
         id: null,
-        data: new Buffer(
+        data: Buffer.from(
             require('!arraybuffer-loader!./builtins/defaultSound.wav') // eslint-disable-line global-require
         )
     },
@@ -39,7 +39,7 @@ const DefaultAssets = [
         type: AssetType.ImageVector,
         format: DataFormat.SVG,
         id: null,
-        data: new Buffer(
+        data: Buffer.from(
             require('!arraybuffer-loader!./builtins/defaultVector.svg') // eslint-disable-line global-require
         )
     }


### PR DESCRIPTION
### Resolves

Resolves #168 

### Proposed Changes

Use `Buffer.from(...)` instead of `new Buffer(...)`.

### Reason for Changes

The `Buffer` constructor has been deprecated since Node 6; this change uses `Buffer.from` instead. Doing so prevents a deprecation message from being displayed in certain contexts, such as when scratch-desktop is started from a terminal.

### Test Coverage

Covered by existing unit tests in `test/unit/load-default-asset.js`. I also inspected the default assets' `data` properties locally.