### PR TITLE
fix: only run build and test with one version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - node_modules
 node_js:
   - "10"
-  - "node"
 install:
   - npm install
   - npm update


### PR DESCRIPTION
Only build and test with one version of node.

Made this a "fix" so it would cause a deploy of a new version to npm.