### PR TITLE
fix: replace Node.js Buffer with buffer npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3990,14 +3990,19 @@
       "dev": true
     },
     "buffer": {
-      "version": "4.9.2",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://bnpm.byted.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://bnpm.byted.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+        }
       }
     },
     "buffer-from": {
@@ -6549,16 +6554,6 @@
         }
       }
     },
-    "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "minipass": "^2.6.0"
-      }
-    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -7188,9 +7183,8 @@
     },
     "ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "resolved": "https://bnpm.byted.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
     },
     "iferr": {
       "version": "0.1.5",
@@ -8422,16 +8416,6 @@
         "yallist": "^3.0.0"
       }
     },
-    "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "minipass": "^2.9.0"
-      }
-    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -8626,6 +8610,19 @@
         "url": "^0.11.0",
         "util": "^0.11.0",
         "vm-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://bnpm.byted.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        }
       }
     },
     "node-releases": {
@@ -17247,22 +17244,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
       "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
       "dev": true
-    },
-    "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
-      }
     },
     "temp-dir": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "arraybuffer-loader": "^1.0.3",
     "base64-js": "1.3.0",
+    "buffer": "^6.0.3",
     "fastestsmallesttextencoderdecoder": "^1.0.7",
     "js-md5": "0.7.3",
     "minilog": "3.1.0",

--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -1,5 +1,5 @@
 const md5 = require('js-md5');
-
+const Buffer = require('buffer').Buffer;
 const log = require('./log');
 
 const Asset = require('./Asset');


### PR DESCRIPTION
fix #30

### Resolves
[https://github.com/LLK/scratch-storage/issues/30]()

### Proposed Changes
It changes the Buffer Node.js API to buffer npm package.

### Reason for Changes
Buffer Node.js API cannot be used on browsers. buffer npm package does, and has identical API to the Node.js ones.

### Test Coverage
No extra tests need to be created. Existing tests were run and passed. 