### PR TITLE
fix: reject get on fetch exception on get resource

### DIFF
--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -20,7 +20,10 @@ class FetchTool {
      */
     get ({url, ...options}) {
         return fetch(url, Object.assign({method: 'GET'}, options))
-            .then(result => result.arrayBuffer())
+            .then(result => {
+                if (result.ok) return result.arrayBuffer();
+                return Promise.reject(result.status);
+            })
             .then(body => new Uint8Array(body));
     }
 

--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -49,7 +49,10 @@ const onMessage = ({data: job}) => {
     jobsActive++;
 
     fetch(job.url, job.options)
-        .then(response => response.arrayBuffer())
+        .then(result => {
+            if (result.ok) return result.arrayBuffer();
+            return Promise.reject(result.status);
+        })
         .then(buffer => complete.push({id: job.id, buffer}))
         .catch(error => complete.push({id: job.id, error}))
         .then(() => jobsActive--);

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -1,4 +1,6 @@
 const test = require('tap').test;
+const TextEncoder = require('util').TextEncoder;
+const TextDecoder = require('util').TextDecoder;
 
 const FetchTool = require('../../src/FetchTool');
 
@@ -24,6 +26,37 @@ test('send failure returns response.status', t => {
     const tool = new FetchTool();
 
     return tool.send('url').catch(reason => {
+        t.equal(reason, 500);
+    });
+});
+
+test('get success returns Uint8Array.body(response.arrayBuffer())', t => {
+    const text = 'successful response';
+    const encoding = 'utf-8';
+    const encoded = new TextEncoder().encode(text);
+    const decoder = new TextDecoder(encoding);
+
+    global.fetch = () => Promise.resolve({
+        ok: true,
+        arrayBuffer: () => encoded.buffer
+    });
+
+    const tool = new FetchTool();
+    
+    return tool.get({url: 'url'}).then(result => {
+        t.equal(decoder.decode(result), text);
+    });
+});
+
+test('get failure returns response.status', t => {
+    global.fetch = () => Promise.resolve({
+        ok: false,
+        status: 500
+    });
+
+    const tool = new FetchTool();
+
+    return tool.get({url: 'url'}).catch(reason => {
         t.equal(reason, 500);
     });
 });


### PR DESCRIPTION
### Resolves

None

### Proposed Changes

Reject on get resource error. fetch() Response.ok == false

### Reason for Changes

Scratch-gui storage works wrong. Backpack feature adds repository for asset type.
If many repository urls set for asset type and first response is 404, then resources not loaded.

### Test Coverage

test/unit/fetch-tool.js
