### PR TITLE
fix: polyfill 'fetch' for Node target

### DIFF
--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -1,7 +1,5 @@
 const md5 = require('js-md5');
 const test = require('tap').test;
-// Polyfill the fetch API
-global.fetch = require('node-fetch');
 
 const ScratchStorage = require('../../dist/node/scratch-storage');
 
@@ -18,6 +16,7 @@ test('constructor', t => {
  * @typedef {object} AssetTestInfo
  * @property {AssetType} type - The type of the asset.
  * @property {string} id - The asset's unique ID.
+ * @property {string} md5 - The asset's MD5 hash.
  * @property {DataFormat} [ext] - Optional: the asset's data format / file extension.
  */
 const testAssets = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const {ProvidePlugin} = require('webpack');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const base = {
@@ -64,6 +65,11 @@ module.exports = [
             'js-md5': true,
             'localforage': true,
             'text-encoding': true
-        }
+        },
+        plugins: [
+            new ProvidePlugin({
+                fetch: ['node-fetch', 'default']
+            })
+        ]
     })
 ];


### PR DESCRIPTION
### Proposed Changes

Configure Webpack to polyfill the `fetch` global with (effectively) `require('node-fetch').default` but only in the `target: 'node'` build.

### Reason for Changes

This allows `FetchTool` to work in versions of Node which don't provide `fetch`. The current `scratch-vm` integration tests are one important example of this problem.

### Test Coverage

Covered by existing tests in `scratch-storage` and `scratch-vm`. The `scratch-vm` integration tests were failing when run with `scratch-storage@1.3.5` but they now pass with this change. I also tested using Node 18.1.0, which does provide `fetch` globally.

Note that the `download-known-asset` test previously defined `global.fetch` itself, which fixed the `fetch` issue for that particular test but didn't help other situations (such as the tests in `scratch-vm`). Now that the fix is at the `webpack` level, the workaround in the `download-known-asset` test is no longer necessary and has been removed.