### PR TITLE
Fix fetch tool error handling

### DIFF
--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -21,7 +21,7 @@ class FetchTool {
     get ({url, ...options}) {
         return fetch(url, Object.assign({method: 'GET'}, options))
             .then(result => {
-                if (result.ok) return new Uint8Array(result.arrayBuffer());
+                if (result.ok) return result.arrayBuffer().then(b => new Uint8Array(b));
                 if (result.status === 404) return null;
                 return Promise.reject(result.status);
             });

--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -21,10 +21,10 @@ class FetchTool {
     get ({url, ...options}) {
         return fetch(url, Object.assign({method: 'GET'}, options))
             .then(result => {
-                if (result.ok) return result.arrayBuffer();
+                if (result.ok) return new Uint8Array(result.arrayBuffer());
+                if (result.status === 404) return null;
                 return Promise.reject(result.status);
-            })
-            .then(body => new Uint8Array(body));
+            });
     }
 
     /**

--- a/src/FetchTool.js
+++ b/src/FetchTool.js
@@ -20,7 +20,10 @@ class FetchTool {
      */
     get ({url, ...options}) {
         return fetch(url, Object.assign({method: 'GET'}, options))
-            .then(result => result.arrayBuffer())
+            .then(result => {
+                if (result.ok) return result.arrayBuffer();
+                return Promise.reject(result.status);
+            })
             .then(body => new Uint8Array(body));
     }
 

--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -51,6 +51,7 @@ const onMessage = ({data: job}) => {
     fetch(job.url, job.options)
         .then(result => {
             if (result.ok) return result.arrayBuffer();
+            if (result.status === 404) return null;
             return Promise.reject(result.status);
         })
         .then(buffer => complete.push({id: job.id, buffer}))

--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -49,7 +49,10 @@ const onMessage = ({data: job}) => {
     jobsActive++;
 
     fetch(job.url, job.options)
-        .then(response => response.arrayBuffer())
+        .then(result => {
+            if (result.ok) return result.arrayBuffer();
+            return Promise.reject(result.status);
+        })
         .then(buffer => complete.push({id: job.id, buffer}))
         .catch(error => complete.push({id: job.id, error}))
         .then(() => jobsActive--);

--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -168,7 +168,7 @@ class ScratchStorage {
      * @param {string} assetId - The ID of the asset to fetch: a project ID, MD5, etc.
      * @param {DataFormat} [dataFormat] - Optional: load this format instead of the AssetType's default.
      * @return {Promise.<Asset>} A promise for the requested Asset.
-     *   If the promise is resolved with non-null, the value is the requested asset or a fallback.
+     *   If the promise is resolved with non-null, the value is the requested asset.
      *   If the promise is resolved with null, the desired asset could not be found with the current asset sources.
      *   If the promise is rejected, there was an error on at least one asset source. HTTP 404 does not count as an
      *   error here, but (for example) HTTP 403 does.
@@ -182,7 +182,7 @@ class ScratchStorage {
         let helperIndex = 0;
         let helper;
         const tryNextHelper = err => {
-            if (err) {
+            if (err) { // Track the error, but continue looking
                 errors.push(err);
             }
 
@@ -198,8 +198,8 @@ class ScratchStorage {
                     // TODO: maybe some types of error should prevent trying the next helper?
                     .catch(tryNextHelper);
             } else if (errors.length > 0) {
-                // At least one thing went wrong and also we couldn't find the
-                // asset.
+                // We looked through all the helpers and couldn't find the asset, AND
+                // at least one thing went wrong while we were looking.
                 return Promise.reject(errors);
             }
 

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -12,9 +12,11 @@ test('send success returns response.text()', t => {
 
     const tool = new FetchTool();
     
-    return tool.send('url').then(result => {
-        t.equal(result, 'successful response');
-    });
+    return t.resolves(
+        tool.send('url').then(result => {
+            t.equal(result, 'successful response');
+        })
+    );
 });
 
 test('send failure returns response.status', t => {
@@ -25,9 +27,7 @@ test('send failure returns response.status', t => {
 
     const tool = new FetchTool();
 
-    return tool.send('url').catch(reason => {
-        t.equal(reason, 500);
-    });
+    return t.rejects(tool.send('url'), 500);
 });
 
 test('get success returns Uint8Array.body(response.arrayBuffer())', t => {
@@ -43,9 +43,11 @@ test('get success returns Uint8Array.body(response.arrayBuffer())', t => {
 
     const tool = new FetchTool();
     
-    return tool.get({url: 'url'}).then(result => {
-        t.equal(decoder.decode(result), text);
-    });
+    return t.resolves(
+        tool.get({url: 'url'}).then(result => {
+            t.equal(decoder.decode(result), text);
+        })
+    );
 });
 
 test('get with 404 response returns null data', t => {
@@ -56,9 +58,11 @@ test('get with 404 response returns null data', t => {
 
     const tool = new FetchTool();
 
-    return tool.get('url').then(result => {
-        t.equal(result, null);
-    });
+    return t.resolves(
+        tool.get('url').then(result => {
+            t.equal(result, null);
+        })
+    );
 });
 
 test('get failure returns response.status', t => {
@@ -69,7 +73,5 @@ test('get failure returns response.status', t => {
 
     const tool = new FetchTool();
 
-    return tool.get({url: 'url'}).catch(reason => {
-        t.equal(reason, 500);
-    });
+    return t.rejects(tool.get({url: 'url'}), 500);
 });

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -38,7 +38,7 @@ test('get success returns Uint8Array.body(response.arrayBuffer())', t => {
 
     global.fetch = () => Promise.resolve({
         ok: true,
-        arrayBuffer: () => encoded.buffer
+        arrayBuffer: () => Promise.resolve(encoded.buffer)
     });
 
     const tool = new FetchTool();

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -48,6 +48,19 @@ test('get success returns Uint8Array.body(response.arrayBuffer())', t => {
     });
 });
 
+test('get with 404 response returns null data', t => {
+    global.fetch = () => Promise.resolve({
+        ok: false,
+        status: 404
+    });
+
+    const tool = new FetchTool();
+
+    return tool.get('url').then(result => {
+        t.equal(result, null);
+    });
+});
+
 test('get failure returns response.status', t => {
     global.fetch = () => Promise.resolve({
         ok: false,

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -1,4 +1,6 @@
 const test = require('tap').test;
+const TextEncoder = require('util').TextEncoder;
+const TextDecoder = require('util').TextDecoder;
 
 const FetchTool = require('../../src/FetchTool');
 
@@ -24,6 +26,37 @@ test('send failure returns response.status', t => {
     const tool = new FetchTool();
 
     return tool.send('url').catch(reason => {
+        t.equal(reason, 500);
+    });
+});
+
+test('get success returns Uint8Array.body(response.arrayBuffer())', t => {
+    const text = 'successful response';
+    const encoding = 'utf-8';
+    const encoded = new TextEncoder().encode(text);
+    const decoder = new TextDecoder(encoding);
+
+    global.fetch = () => Promise.resolve({
+        ok: true,
+        arrayBuffer: () => encoded.buffer
+    });
+
+    const tool = new FetchTool();
+    
+    return tool.get({url: 'url'}).then(result => {
+        t.equal(decoder.decode(result), text);
+    });
+});
+
+test('get failure returns response.status', t => {
+    global.fetch = () => Promise.resolve({
+        ok: false,
+        status: 500
+    });
+
+    const tool = new FetchTool();
+
+    return tool.get({url: 'url'}).catch(reason => {
         t.equal(reason, 500);
     });
 });


### PR DESCRIPTION
### Resolves

Builds on and closes #363
Closes #156 

### Proposed Changes

This PR builds on top of #363.

In addition to the changes from that PR, these changes:
- Add special support for a 404 response while searching for the requested asset
- When all our sources are checked and the asset was nowhere to be found (e.g. all the web sources 404'd and did not have any other errors), resolve null for the requested asset.
- If the asset was not found but there were also errors with the tools we were using to request the asset, track and report

### Reason for Changes

- Fix an issue with asset loading where if the asset is missing, storage was resolving an html 404 page as the requested asset data.
- Also fixes an issue where we were not properly handling the case when the WebHelper has exhausted all the stores to check
- Make sure the `WebHelper.load` function is consistent with the documented API of `ScratchStorage.load`
- Make sure WebHelper returns a null Asset when the asset could not be found instead of a skeleton Asset with a null `data` field.

### Test Coverage

- #363 adds tests for 200 and 500 responses.
- added another FetchTool unit test for the 404 response