### PR TITLE
fix(fetchworkertool): don't create Uint8Array for null response

### DIFF
--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -96,7 +96,8 @@ class PrivateFetchWorkerTool {
                 reject
             };
         })
-            .then(body => new Uint8Array(body));
+            /* eslint no-confusing-arrow: ["error", {"allowParens": true}] */
+            .then(body => (body ? new Uint8Array(body) : null));
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

Resolves issue missed by #388 where if FetchWorkerTool.worker resolves with null, FetchWorkerTool turns that into an empty Uint8Array. Resolve null instead.