### PR TITLE
fix(worker): report worker errors as strings

### DIFF
--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -55,7 +55,7 @@ const onMessage = ({data: job}) => {
             return Promise.reject(result.status);
         })
         .then(buffer => complete.push({id: job.id, buffer}))
-        .catch(error => complete.push({id: job.id, error}))
+        .catch(error => complete.push({id: job.id, error: error.message || `Failed request: ${job.url}`}))
         .then(() => jobsActive--);
 };
 
@@ -65,6 +65,6 @@ if (self.fetch) {
 } else {
     postMessage({support: {fetch: false}});
     self.addEventListener('message', ({data: job}) => {
-        postMessage([{id: job.id, error: new Error('fetch is unavailable')}]);
+        postMessage([{id: job.id, error: 'fetch is unavailable'}]);
     });
 }

--- a/src/FetchWorkerTool.worker.js
+++ b/src/FetchWorkerTool.worker.js
@@ -55,7 +55,7 @@ const onMessage = ({data: job}) => {
             return Promise.reject(result.status);
         })
         .then(buffer => complete.push({id: job.id, buffer}))
-        .catch(error => complete.push({id: job.id, error: error.message || `Failed request: ${job.url}`}))
+        .catch(error => complete.push({id: job.id, error: (error && error.message) || `Failed request: ${job.url}`}))
         .then(() => jobsActive--);
 };
 


### PR DESCRIPTION
### Proposed Changes

If the `FetchWorkerTool` encounters an error, record it in the completion queue as a string, not an `Error` object.

### Reason for Changes

Error objects can't be sent with `postMessage`, so the previous code would throw an exception when trying to send the error back to the main thread.

### Test Coverage

Tested locally