### PR TITLE
Fix tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,68 +2,32 @@
 version: 2.1
 orbs:
   commitlint: conventional-changelog/commitlint@1.0.0
-  
-executors:
-  default-executor:
-    docker:
-      - image: "cimg/node:10.22.0"
-    working_directory: ~/project
-    resource_class: medium
-
-commands:
-  restore_test_cache:
-    steps:
-      - restore_cache:
-          keys:
-            - v1-deps-{{ checksum "package-lock.json" }}
-            - v1-deps-
-  save_test_cache:
-    steps:
-      - save_cache:
-          key: v1-deps-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
-  setup:
-    steps:
-      - run:
-          name: Setup
-          command: |
-            npm install
-            npm update
-            npm prune
-
-  test:
-    steps:
-      - run:
-          name: Test
-          command: |
-            npm run build
-            npm run test
-  deploy:
-    steps:
-      - run:
-          name: Deploy
-          command: |
-            npm run semantic-release
+  node: circleci/node@5.1
 
 jobs:
   build-and-test:
-    executor: default-executor
+    executor:
+      name: node/default
+      resource_class: medium
+      tag: '16.19'
     steps:
       - checkout
-      - restore_test_cache
-      - setup
-      - save_test_cache
-      - test
+      - node/install-packages
+      - run: npm run build
+      - run: npm run test
       - persist_to_workspace:
           root: ~/project
-          paths: .
+          paths:
+            - .
   deploy:
-    executor: default-executor
+    executor:
+      name: node/default
+      resource_class: medium
+      tag: '16.19'
     steps:
       - attach_workspace:
           at: ~/project
-      - deploy
+      - run: npm run semantic-release
 
 workflows:
   commitlint:

--- a/test/integration/download-known-assets.js
+++ b/test/integration/download-known-assets.js
@@ -66,9 +66,9 @@ const testAssets = [
     }
 ];
 
-test('addWebSource', t => {
+test('addWebStore', t => {
     t.doesNotThrow(() => {
-        storage.addWebSource(
+        storage.addWebStore(
             [storage.AssetType.Project],
             asset => {
                 const idParts = asset.assetId.split('.');
@@ -78,7 +78,7 @@ test('addWebSource', t => {
             });
     });
     t.doesNotThrow(() => {
-        storage.addWebSource(
+        storage.addWebStore(
             [storage.AssetType.ImageVector, storage.AssetType.ImageBitmap, storage.AssetType.Sound],
             asset => `https://cdn.assets.scratch.mit.edu/internalapi/asset/${asset.assetId}.${asset.dataFormat}/get/`
         );
@@ -95,15 +95,15 @@ test('load', t => {
                 throw new Error(`failed to load ${assetInfo.type.name} asset with id=${assetInfo.id} (e=${e})`);
             });
         t.type(asset, storage.Asset);
-        t.strictEqual(asset.assetId, assetInfo.id);
-        t.strictEqual(asset.assetType, assetInfo.type);
+        t.equal(asset.assetId, assetInfo.id);
+        t.equal(asset.assetType, assetInfo.type);
         t.ok(asset.data.length);
 
         // Web assets should come back as clean
-        t.true(asset.clean);
+        t.ok(asset.clean);
 
         if (assetInfo.md5) {
-            t.strictEqual(md5(asset.data), assetInfo.md5);
+            t.equal(md5(asset.data), assetInfo.md5);
         }
     });
 


### PR DESCRIPTION
### Proposed Changes

Main change: stop trying to download project files as part of `download-known-assets` test

Supporting changes:

* Modernize the CircleCI config in this repository:
  * Use the Node orb, including its method for installing and caching dependencies
  * Move from Node 10 to Node 16
* Simplify & modernize `download-known-assets` test
* Add better reporting for `storage.load` failures during `download-known-assets` test
* Replace deprecated calls with their supported equivalents

### Reason for Changes

It took me a while to understand what was going wrong because the part of the log detailing the test failure looked like this:

```
  not ok (unnamed test)
    '0': []
```

So my first order of business was to improve that output. I did the "update & modernize" stuff along the way, trying to rule out "I did promises wrong" as a cause for the failure or the bad output. I didn't understand promises very well back when I wrote these tests, so "I did promises wrong" seemed like a strong candidate.

Turns out, the rejection output of `storage.load` on a failure is an HTTP error code, not an `Error` object. We should probably fix that, but that's an API change that I'll want to be more careful about. For now, I adjusted the test to wrap the output in an `Error` with a descriptive message.

Now, the same failure looks like:

```
  not ok failed to load Project asset with id=117504922.d6ae1ffb76f2bc83421cd3f40fc4fd57 (e=403)
```

Aha! Right. We can't just load project files willy-nilly these days. The real problem had nothing to do with the Node version, or promises, or any of that. _sigh_

Well, they're all good changes anyway. Or, at least, I think they are. What do you think?
