### PR TITLE
Improve scratchFetch metadata and testing

### DIFF
--- a/src/FetchWorkerTool.js
+++ b/src/FetchWorkerTool.js
@@ -1,4 +1,4 @@
-const {applyMetadata} = require('./scratchFetch');
+const {Headers, applyMetadata} = require('./scratchFetch');
 
 /**
  * Get and send assets with a worker that uses fetch.
@@ -92,6 +92,13 @@ class PrivateFetchWorkerTool {
             const augmentedOptions = applyMetadata(
                 Object.assign({method: 'GET'}, options)
             );
+            // the Fetch spec says options.headers could be:
+            // "A Headers object, an object literal, or an array of two-item arrays to set request's headers."
+            // structured clone (postMessage) doesn't support Headers objects
+            // so turn it into an array of two-item arrays to make it to the worker intact
+            if (augmentedOptions && augmentedOptions.headers instanceof Headers) {
+                augmentedOptions.headers = Array.from(augmentedOptions.headers.entries());
+            }
             this.worker.postMessage({
                 id,
                 url,

--- a/src/ScratchStorage.js
+++ b/src/ScratchStorage.js
@@ -6,6 +6,7 @@ const WebHelper = require('./WebHelper');
 const _Asset = require('./Asset');
 const _AssetType = require('./AssetType');
 const _DataFormat = require('./DataFormat');
+const _scratchFetch = require('./scratchFetch');
 
 class ScratchStorage {
     constructor () {
@@ -49,6 +50,14 @@ class ScratchStorage {
      */
     get DataFormat () {
         return _DataFormat;
+    }
+
+    /**
+     * Access the `scratchFetch` module within this library.
+     * @return {module} the scratchFetch module, with properties for `scratchFetch`, `setMetadata`, etc.
+     */
+    get scratchFetch () {
+        return _scratchFetch;
     }
 
     /**

--- a/src/scratchFetch.js
+++ b/src/scratchFetch.js
@@ -1,4 +1,4 @@
-const {fetch, Headers} = require('cross-fetch');
+const crossFetch = require('cross-fetch');
 
 /**
  * Metadata header names
@@ -16,7 +16,7 @@ const RequestMetadata = {
  * Metadata headers for requests
  * @type {Headers}
  */
-const metadata = new Headers();
+const metadata = new crossFetch.Headers();
 
 /**
  * Check if there is any metadata to apply.
@@ -41,13 +41,13 @@ const hasMetadata = () => {
 const applyMetadata = options => {
     if (hasMetadata()) {
         const augmentedOptions = Object.assign({}, options);
-        augmentedOptions.headers = new Headers(metadata);
+        augmentedOptions.headers = new crossFetch.Headers(metadata);
         if (options && options.headers) {
             // the Fetch spec says options.headers could be:
             // "A Headers object, an object literal, or an array of two-item arrays to set request's headers."
             // turn it into a Headers object to be sure of how to interact with it
-            const overrideHeaders =
-                options.headers instanceof Headers ? options.headers : new Headers(options.headers);
+            const overrideHeaders = options.headers instanceof crossFetch.Headers ?
+                options.headers : new crossFetch.Headers(options.headers);
             for (const [name, value] of overrideHeaders.entries()) {
                 augmentedOptions.headers.set(name, value);
             }
@@ -67,7 +67,7 @@ const applyMetadata = options => {
  */
 const scratchFetch = (resource, options) => {
     const augmentedOptions = applyMetadata(options);
-    return fetch(resource, augmentedOptions);
+    return crossFetch.fetch(resource, augmentedOptions);
 };
 
 /**
@@ -92,7 +92,7 @@ const unsetMetadata = name => {
 module.exports = {
     default: scratchFetch,
 
-    Headers,
+    Headers: crossFetch.Headers,
     RequestMetadata,
     applyMetadata,
     scratchFetch,

--- a/src/scratchFetch.js
+++ b/src/scratchFetch.js
@@ -85,3 +85,15 @@ module.exports = {
     setMetadata,
     unsetMetadata
 };
+
+if (process.env.NODE_ENV === 'development') {
+    /**
+     * Retrieve a named request metadata item.
+     * Only for use in tests.
+     * @param {RequestMetadata} name The name of the metadata item to retrieve.
+     * @returns {any} value The value of the metadata item, or `undefined` if it was not found.
+     */
+    const getMetadata = name => metadata.get(name);
+
+    module.exports.getMetadata = getMetadata;
+}

--- a/src/scratchFetch.js
+++ b/src/scratchFetch.js
@@ -13,10 +13,21 @@ const RequestMetadata = {
 };
 
 /**
- * Metadata for requests
- * @type {Map<string, string>}
+ * Metadata headers for requests
+ * @type {Headers}
  */
-const metadata = new Map();
+const metadata = new Headers();
+
+/**
+ * Check if there is any metadata to apply.
+ * @returns {boolean} true if `metadata` has contents, or false if it is empty.
+ */
+const hasMetadata = () => {
+    for (const _ of metadata) {
+        return true;
+    }
+    return false;
+};
 
 /**
  * Non-destructively merge any metadata state (if any) with the provided options object (if any).
@@ -28,10 +39,13 @@ const metadata = new Map();
  * @returns {RequestInit|undefined} the provided options parameter without modification, or a new options object.
  */
 const applyMetadata = options => {
-    if (metadata.size > 0) {
+    if (hasMetadata()) {
         const augmentedOptions = Object.assign({}, options);
-        augmentedOptions.headers = new Headers(Array.from(metadata));
+        augmentedOptions.headers = new Headers(metadata);
         if (options && options.headers) {
+            // the Fetch spec says options.headers could be:
+            // "A Headers object, an object literal, or an array of two-item arrays to set request's headers."
+            // turn it into a Headers object to be sure of how to interact with it
             const overrideHeaders =
                 options.headers instanceof Headers ? options.headers : new Headers(options.headers);
             for (const [name, value] of overrideHeaders.entries()) {

--- a/src/scratchFetch.js
+++ b/src/scratchFetch.js
@@ -7,9 +7,9 @@ const crossFetch = require('cross-fetch');
  */
 const RequestMetadata = {
     /** The ID of the project associated with this request */
-    ProjectId: 'X-ProjectId',
+    ProjectId: 'X-Project-ID',
     /** The ID of the project run associated with this request */
-    RunId: 'X-RunId'
+    RunId: 'X-Run-ID'
 };
 
 /**

--- a/src/scratchFetch.js
+++ b/src/scratchFetch.js
@@ -78,6 +78,7 @@ const unsetMetadata = name => {
 module.exports = {
     default: scratchFetch,
 
+    Headers,
     RequestMetadata,
     applyMetadata,
     scratchFetch,

--- a/test/mocks/mock-fetch.js
+++ b/test/mocks/mock-fetch.js
@@ -1,6 +1,7 @@
 const TextEncoder = require('util').TextEncoder;
-const {Headers} = require('cross-fetch');
+const crossFetch = require('cross-fetch');
 
+const Headers = crossFetch.Headers;
 const successText = 'successful response';
 
 /**
@@ -58,7 +59,11 @@ const mockFetch = (resource, options) => {
     return Promise.resolve(results);
 };
 
+// Mimic the cross-fetch module, but replace its `fetch` with `mockFetch` and add a few extras
 module.exports = {
+    ...crossFetch, // Headers, Request, Response, etc.
+    default: mockFetch,
+    fetch: mockFetch,
     mockFetch,
     successText
 };

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -1,5 +1,6 @@
 const tap = require('tap');
 const TextDecoder = require('util').TextDecoder;
+const crossFetch = require('cross-fetch');
 
 const {mockFetch, successText} = require('../mocks/mockFetch.js');
 
@@ -9,6 +10,7 @@ const {mockFetch, successText} = require('../mocks/mockFetch.js');
  */
 const FetchTool = tap.mock('../../src/FetchTool', {
     'cross-fetch': {
+        ...crossFetch, // Headers, etc.
         default: mockFetch,
         fetch: mockFetch
     }

--- a/test/unit/fetch-tool.js
+++ b/test/unit/fetch-tool.js
@@ -1,19 +1,14 @@
 const tap = require('tap');
 const TextDecoder = require('util').TextDecoder;
-const crossFetch = require('cross-fetch');
 
-const {mockFetch, successText} = require('../mocks/mockFetch.js');
+const mockFetch = require('../mocks/mock-fetch.js');
 
 /**
  * This is the real FetchTool, but the 'cross-fetch' module has been replaced with the mockFetch function.
  * @type {typeof import('../../src/FetchTool')}
  */
 const FetchTool = tap.mock('../../src/FetchTool', {
-    'cross-fetch': {
-        ...crossFetch, // Headers, etc.
-        default: mockFetch,
-        fetch: mockFetch
-    }
+    'cross-fetch': mockFetch
 });
 
 tap.test('send success returns response.text()', t => {
@@ -21,7 +16,7 @@ tap.test('send success returns response.text()', t => {
 
     return t.resolves(
         tool.send({url: '200'}).then(result => {
-            t.equal(result, successText);
+            t.equal(result, mockFetch.successText);
         })
     );
 });
@@ -40,7 +35,7 @@ tap.test('get success returns Uint8Array.body(response.arrayBuffer())', t => {
 
     return t.resolves(
         tool.get({url: '200'}).then(result => {
-            t.equal(decoder.decode(result), successText);
+            t.equal(decoder.decode(result), mockFetch.successText);
         })
     );
 });

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -127,3 +127,21 @@ tap.test('selectively delete metadata', async t => {
     t.equal(mockFetchTestData.headers?.get(RequestMetadata.ProjectId), null); // value `null` means it's missing
     t.equal(mockFetchTestData.headers?.get(RequestMetadata.RunId), 'undefined');
 });
+
+tap.test('metadata has case-insensitive keys', async t => {
+    const {scratchFetchModule, FetchTool} = setupModules();
+    const {setMetadata} = scratchFetchModule;
+
+    setMetadata('foo', 1);
+    setMetadata('FOO', 2);
+
+    const tool = new FetchTool();
+
+    /** @type import('../mocks/mock-fetch.js').MockFetchTestData */
+    const mockFetchTestData = {};
+    await tool.get({url: '200', mockFetchTestData});
+
+    t.ok(mockFetchTestData.headers, 'mockFetch did not report headers');
+    t.equal(mockFetchTestData.headersCount, 1);
+    t.equal(mockFetchTestData.headers?.get('foo'), '2');
+});

--- a/test/unit/metadata.js
+++ b/test/unit/metadata.js
@@ -1,14 +1,7 @@
 const tap = require('tap');
 
-const crossFetch = require('cross-fetch');
+const mockFetchModule = require('../mocks/mock-fetch.js');
 
-const {mockFetch} = require('../mocks/mockFetch.js');
-
-const mockFetchModule = {
-    ...crossFetch, // Headers, Request, Response, etc.
-    default: mockFetch,
-    fetch: mockFetch
-};
 
 // Call this separately from each test to ensure that metadata gets reset.
 // This is especially important when parallelizing tests!
@@ -39,7 +32,7 @@ tap.test('get without metadata', async t => {
 
     const tool = new FetchTool();
 
-    /** @type import('../mocks/mockFetch.js').MockFetchTestData */
+    /** @type import('../mocks/mock-fetch.js').MockFetchTestData */
     const mockFetchTestData = {};
     const result = await tool.get({url: '200', mockFetchTestData});
 
@@ -57,7 +50,7 @@ tap.test('get with metadata', async t => {
     setMetadata(RequestMetadata.ProjectId, 1234);
     setMetadata(RequestMetadata.RunId, 5678);
 
-    /** @type import('../mocks/mockFetch.js').MockFetchTestData */
+    /** @type import('../mocks/mock-fetch.js').MockFetchTestData */
     const mockFetchTestData = {};
     const result = await tool.get({url: '200', mockFetchTestData});
 
@@ -73,7 +66,7 @@ tap.test('send without metadata', async t => {
 
     const tool = new FetchTool();
 
-    /** @type import('../mocks/mockFetch.js').MockFetchTestData */
+    /** @type import('../mocks/mock-fetch.js').MockFetchTestData */
     const mockFetchTestData = {};
     const result = await tool.send({url: '200', mockFetchTestData});
 
@@ -91,7 +84,7 @@ tap.test('send with metadata', async t => {
     setMetadata(RequestMetadata.ProjectId, 4321);
     setMetadata(RequestMetadata.RunId, 8765);
 
-    /** @type import('../mocks/mockFetch.js').MockFetchTestData */
+    /** @type import('../mocks/mock-fetch.js').MockFetchTestData */
     const mockFetchTestData = {};
     const result = await tool.send({url: '200', mockFetchTestData});
 
@@ -112,7 +105,7 @@ tap.test('selectively delete metadata', async t => {
 
     const tool = new FetchTool();
 
-    /** @type import('../mocks/mockFetch.js').MockFetchTestData */
+    /** @type import('../mocks/mock-fetch.js').MockFetchTestData */
     const mockFetchTestData = {};
 
     const result1 = await tool.send({url: '200', mockFetchTestData});


### PR DESCRIPTION
### Proposed Changes

The main changes here are:
- transmit headers from `FetchWorkerTool.js` to `FetchWorkerTool.worker.js` as an array instead of a `Headers` object.
- expose `scratchFetch` through a getter on `ScratchStorage` instances

Also:
- store headers in a `Headers` object instead of a `Map`
- changes to the way the `fetch` function & `cross-fetch` module are mocked for tests

### Reason for Changes

While testing the `scratchFetch` in isolation, everything seemed good. Once I started testing it in `scratch-gui` setting a project ID, which only happens in the context of `scratch-www` connected to a project server, I started seeing errors when loading projects. Specifically, I was seeing CORS errors complaining about a header named `map`. I tracked this down to the `postMessage` in `FetchWorkerTool`: it was trying to send a `Headers` object instance, but `postMessage` doesn't support that. The `postMessage` was doing the best it could to turn the `cross-fetch` implementation of `Headers` into a plain object, which means it was getting a member called `map` based on its internal structure. The worker would then do as it was told and send a `map` header. So that's where the `Array.from()` comes from: that field is allowed to be a `Headers` object or anything that can be passed to the `Headers` constructor, which includes things like `{a:'A', b:'B'}` or `[['a','A'],['b','B']]`. I picked the array one because I'm (overly?) paranoid about stray properties in an Object.

Also in testing, I was running into trouble where two parts of the code (like a test in `scratch-gui` vs. code inside `scratch-vm`). I resolved this by adding a getter for `scratchFetch` on `ScratchStorage` so that all code sharing a particular instance of `scratch-storage` can share a single `scratchFetch` and its `metadata` object.

Storing headers in `Headers` object is just a nice-to-have meant to make `setMetadata` and `getMetadata` reflect what will actually happen with the headers. This means that `setMetadata('x-runid', ...)` will override `setMetadata('x-RunId', ...)`, for example. Also, if you try to set a header with an invalid character in its name, you'll get an error right away instead of the error being delayed until the next `scratchFetch` attempt.

I also ran into trouble testing because I mocked `cross-fetch` differently in two tests and missed that. I refactored the way I'm mocking `cross-fetch` so it's harder to make that mistake in the future.

### Test Coverage

Existing tests have been adjusted to cover the new structure, and I added one for case sensitivity in metadata keys.