### PR TITLE
Control scratchFetch with a query param

### DIFF
--- a/src/scratchFetch.js
+++ b/src/scratchFetch.js
@@ -23,6 +23,19 @@ const metadata = new crossFetch.Headers();
  * @returns {boolean} true if `metadata` has contents, or false if it is empty.
  */
 const hasMetadata = () => {
+    /* global self */
+    const searchParams = (
+        typeof self !== 'undefined' &&
+        self &&
+        self.location &&
+        self.location.search &&
+        self.location.search.split(/[?&]/)
+    ) || [];
+    if (!searchParams.includes('scratchMetadata=1')) {
+        // for now, disable this feature unless scratchMetadata=1
+        // TODO: remove this check once we're sure the feature works correctly in production
+        return false;
+    }
     for (const _ of metadata) {
         return true;
     }

--- a/test/unit/metadata.test.js
+++ b/test/unit/metadata.test.js
@@ -5,6 +5,12 @@ beforeEach(() => {
     // but this also means we need to `require` inside the tests
     /* eslint-disable global-require */
     jest.resetModules();
+
+    // temporary: pretend we're running in a browser and the URL has scratchMetadata=1
+    // this is a hack to enable the metadata feature in tests
+    // see also `hasMetadata` in scratchFetch.js
+    global.self = global.self || {};
+    global.self.location = new URL('https://example.com/?scratchMetadata=1');
 });
 
 test('get without metadata', async () => {


### PR DESCRIPTION
### Proposed Changes

Don't add metadata in `scratchFetch` unless the location includes `scratchMetadata=1`

### Reason for Changes

This should let us test the metadata changes in production without the risk of breaking the site for everyone.

### Test Coverage

Tested locally using `npm link` and logpoints in Chrome.
