### PR TITLE
Fix scratch-storage@2.3.x for browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/LLK/scratch-storage.git"
   },
   "main": "./dist/node/scratch-storage.js",
-  "browser": "./src/index.js",
+  "browser": "./dist/web/scratch-storage.js",
   "scripts": {
     "build": "webpack --progress --colors --bail",
     "coverage": "tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",

--- a/test/unit/load-default-assets.test.js
+++ b/test/unit/load-default-assets.test.js
@@ -1,6 +1,13 @@
 const md5 = require('js-md5');
 
-const ScratchStorage = require('../../src/index.js');
+const ScratchStorage = require('../../dist/node/scratch-storage');
+
+// Hash and file size of each default asset
+const knownSizes = {
+    '8e768a5a5a01891b05c01c9ca15eb6aa': 255,
+    'b586745b98e94d7574f7f7b48d831e20': 46,
+    'e5cb3b2aa4e1a9b4c735c3415e507e66': 925
+};
 
 const getDefaultAssetTypes = storage => {
     const defaultAssetTypes = [storage.AssetType.ImageBitmap, storage.AssetType.ImageVector, storage.AssetType.Sound];
@@ -42,6 +49,7 @@ test('load', () => {
         expect(asset.assetId).toStrictEqual(id);
         expect(asset.assetType).toStrictEqual(assetType);
         expect(asset.data.length).toBeTruthy();
+        expect(asset.data.length).toBe(knownSizes[id]);
         expect(md5(asset.data)).toBe(id);
     };
     for (const assetType of defaultAssetTypes) {


### PR DESCRIPTION
### Resolves

- Likely resolves ENG-107

### Proposed Changes

Update the `browser` field in `package.json` to point to `dist/web/scratch-storage.js` instead of `src/index.js`

### Reason for Changes

Browsers don't understand `webpack` loaders, so strictly speaking, this field has been incorrect since we first implemented default assets. We didn't notice because, within Scratch repositories, we always build with `webpack`. Removing the inline loader syntax in #412 made it so that dependents need to specify loader rules, and thus broke `scratch-gui` and others. Telling dependents to use the build output makes it so the loader is applied as part of the `scratch-storage` build process and doesn't need to be configured in every dependent. Also, FLUFFY FISHSTICKS this took SO much longer than it should have. It's exceptionally difficult to fix this at the `scratch-gui` level, which is what I was beating my head against for a few days. I'm very happysad that it's effectively a one-liner in `scratch-storage`.

### Test Coverage

I enhanced the `load-default-assets` test to verify the exact size of each default asset. That way, we can be sure that the file contents are accurate instead of, for example, a filename or a data URI string. Basically, it now tests that the loader is doing its job and configured correctly. To do this, it needs to use the build output instead of the raw source.