### PR TITLE
fix: fix web worker usage in scratch-vm integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/runtime": "^7.21.0",
         "arraybuffer-loader": "^1.0.3",
         "base64-js": "^1.3.0",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "fastestsmallesttextencoderdecoder": "^1.0.7",
         "js-md5": "^0.7.3",
         "minilog": "^3.1.0"
@@ -8371,9 +8371,9 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/runtime": "^7.21.0",
     "arraybuffer-loader": "^1.0.3",
     "base64-js": "^1.3.0",
-    "cross-fetch": "^3.1.5",
+    "cross-fetch": "^4.0.0",
     "fastestsmallesttextencoderdecoder": "^1.0.7",
     "js-md5": "^0.7.3",
     "minilog": "^3.1.0"

--- a/src/scratchFetch.js
+++ b/src/scratchFetch.js
@@ -102,23 +102,20 @@ const unsetMetadata = name => {
     metadata.delete(name);
 };
 
+/**
+ * Retrieve a named request metadata item.
+ * Only for use in tests. At the time of writing, used in scratch-vm tests.
+ * @param {RequestMetadata} name The name of the metadata item to retrieve.
+ * @returns {any} value The value of the metadata item, or `undefined` if it was not found.
+ */
+const getMetadata = name => metadata.get(name);
+
 module.exports = {
     Headers: crossFetch.Headers,
     RequestMetadata,
     applyMetadata,
     scratchFetch,
     setMetadata,
-    unsetMetadata
+    unsetMetadata,
+    getMetadata
 };
-
-if (process.env.NODE_ENV === 'development') {
-    /**
-     * Retrieve a named request metadata item.
-     * Only for use in tests.
-     * @param {RequestMetadata} name The name of the metadata item to retrieve.
-     * @returns {any} value The value of the metadata item, or `undefined` if it was not found.
-     */
-    const getMetadata = name => metadata.get(name);
-
-    module.exports.getMetadata = getMetadata;
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,10 +27,11 @@ if (!process.env.CI) {
 const webConfig = baseConfig.clone()
     .merge({
         output: {
-            library: 'ScratchStorage',
-            libraryTarget: 'umd',
+            library: {
+                name: 'ScratchStorage',
+                type: 'umd2'
+            },
             path: path.resolve(__dirname, 'dist', 'web'),
-            filename: '[name].js',
             clean: false
         }
     });
@@ -62,10 +63,11 @@ const nodeConfig = baseConfig.clone()
             'scratch-storage': path.join(__dirname, './src/index.ts')
         },
         output: {
-            libraryTarget: 'commonjs2',
+            library: {
+                type: 'commonjs2'
+            },
             chunkFormat: 'commonjs',
             path: path.resolve(__dirname, 'dist', 'node'),
-            filename: '[name].js',
             clean: false
         }
     })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,7 @@ const nodeConfig = baseConfig.clone()
         },
         output: {
             libraryTarget: 'commonjs2',
+            chunkFormat: 'commonjs',
             path: path.resolve(__dirname, 'dist', 'node'),
             filename: '[name].js',
             clean: false


### PR DESCRIPTION
See https://github.com/lquixada/cross-fetch/issues/78 for why it was necessary to update cross-fetch.
Also needed to expose getMetadata as with webpack 5 it seems to get eliminated (as we're building with NODE_ENV=production now due to some auto-optimizations with webpack 5)