### PR TITLE
Fix relative worker path for non-root deployments

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,8 @@ const baseConfig = new ScratchWebpackConfigBuilder(
         rootPath: path.resolve(__dirname),
         enableReact: false,
         enableTs: true,
-        shouldSplitChunks: false
+        shouldSplitChunks: false,
+        publicPath: 'auto'
     })
     .setTarget('browserslist')
     .merge({


### PR DESCRIPTION
### Resolves

_Fixes issue where `fetch-worker.*` files are placed in root-level `https://<server>/chunks/` when `scratch-editor` is deployed to a non-root path, causing worker loading failures._

### Proposed Changes

This Pull Request modifies the webpack configuration to use relative paths for chunk loading instead of absolute paths. The key change is setting `publicPath: 'auto'` in the webpack configuration, which ensures that:

- Worker files (`fetch-worker.*`) are loaded relative to the deployed application path
- Chunks are properly resolved when `scratch-editor` is deployed to subdirectories
- The application works correctly regardless of deployment path

### Reason for Changes

When `scratch-editor` is deployed to a non-root path (e.g., `https://example.com/my-app/`), the current configuration places worker chunks at the server root (`https://example.com/chunks/`) instead of relative to the application (`https://example.com/my-app/chunks/`). This causes:

- 404 errors when trying to load worker files
- Application failures in subdirectory deployments
- Deployment flexibility issues

By using relative paths, the worker files will be correctly located relative to where the main application is deployed, ensuring compatibility with various deployment scenarios.
