### PR TITLE
Revert "Fix relative worker path for non-root deployments"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,6 @@ const webConfig = baseConfig.clone()
                 type: 'umd2'
             },
             path: path.resolve(__dirname, 'dist', 'web'),
-            publicPath: 'auto',
             clean: false
         }
     });


### PR DESCRIPTION
### Proposed Changes

Reverts scratchfoundation/scratch-storage#786

### Reason for Changes

Unfortunately, this change broke asset loading when the editor is loaded into `scratch-www`. I'm reverting it as a "quick fix," but I could see bringing it back if we find a way to make it work correctly in the context of `scratch-www`. Ideally, I'd like to come up with a test that fails with `scratch-storage@6.1.4` but passes with `publicPath: 'auto'` and some other changes (either here or in `-www`).

Sorry, @yokobond ! I hope we can figure this out for a future version.